### PR TITLE
Fix some docs and comments typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/arquivei/foundationkit)](https://goreportcard.com/report/github.com/arquivei/foundationkit)
 
-This project contains very opinionated packages for comom operations.
+This project contains very opinionated packages for common operations.
 

--- a/errors/code.go
+++ b/errors/code.go
@@ -13,7 +13,7 @@ const (
 	ErrorCodeEmpty = Code("")
 )
 
-// GetErrorCode returns the error code. If the error doen't contains an error code, returns ErrorCodeEmpty.
+// GetErrorCode returns the error code. If the error doesn't contains an error code, returns ErrorCodeEmpty.
 func GetErrorCode(err error) Code {
 	for {
 		e, ok := err.(Error)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -72,7 +72,7 @@ func (e Error) String() string {
 	return e.Error()
 }
 
-// E is a helper hunction for builder errors
+// E is a helper function for builder errors
 func E(args ...interface{}) error {
 	e := Error{}
 	if len(args) == 0 {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -69,5 +69,5 @@ func TestErrorString_NoError(t *testing.T) {
 	}()
 	err := Error{}
 	stringError = err.Error()
-	assert.FailNow(t, "panic didn't occured")
+	assert.FailNow(t, "panic didn't occurred")
 }

--- a/errors/severity.go
+++ b/errors/severity.go
@@ -1,7 +1,7 @@
 package errors
 
-// Severity is the error severity. It's used to classify errors in groups to be easily handled by the code. For examle,
-// a retry layer should be only checking for Runtime erros to retry. Or in an HTTP layer, erros of input type are always
+// Severity is the error severity. It's used to classify errors in groups to be easily handled by the code. For example,
+// a retry layer should be only checking for Runtime errors to retry. Or in an HTTP layer, errors of input type are always
 // returned a 400 status.
 type Severity string
 

--- a/errors/severity_test.go
+++ b/errors/severity_test.go
@@ -16,7 +16,7 @@ func TestGetSeverity(t *testing.T) {
 	assert.Equal(t, SeverityInput, GetSeverity(err))
 	assert.EqualError(t, err, "my error")
 
-	// Wraps error winth runtime severiry
+	// Wraps error with runtime severity
 	err = Error{
 		Severity: SeverityRuntime,
 		Err:      err,
@@ -26,7 +26,7 @@ func TestGetSeverity(t *testing.T) {
 	assert.EqualError(t, err, "my error")
 
 	// Wraps error with an error with without severity
-	// Keeps previous severiry
+	// Keeps previous severity
 	err = Error{
 		Err: err,
 	}

--- a/log/stackdriver_hook.go
+++ b/log/stackdriver_hook.go
@@ -18,7 +18,7 @@ var LevelToSeverity = func(level zerolog.Level) logging.Severity {
 	switch level {
 	case zerolog.DebugLevel:
 		return logging.Debug
-	// Let info falls into the defualt
+	// Let info falls into the default
 	case zerolog.WarnLevel:
 		return logging.Warning
 	case zerolog.ErrorLevel:


### PR DESCRIPTION
I was reading the project documentation/comments and catch some minor typo errors.

This PR fix the ones that I found.