### PR TITLE
Adds the trace package

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -1,0 +1,24 @@
+package trace
+
+import "context"
+
+type contextKeyType int
+
+const (
+	contextKeyTraceID contextKeyType = iota
+)
+
+// WithTraceID instantiates a new child context from @parent with the
+// given @traceID value set
+func WithTraceID(parent context.Context, traceID ID) context.Context {
+	return context.WithValue(parent, contextKeyTraceID, traceID)
+}
+
+// GetTraceIDFromContext returns the trace ID set in the context, if any,
+// or an empty trace id if none is set
+func GetTraceIDFromContext(ctx context.Context) ID {
+	if id, ok := ctx.Value(contextKeyTraceID).(ID); ok {
+		return id
+	}
+	return ID{}
+}

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -1,0 +1,17 @@
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceIDContextOperations(t *testing.T) {
+	ctx := context.Background()
+	assert.True(t, IDIsEmpty(GetTraceIDFromContext(ctx)))
+
+	id := NewTraceID()
+	ctx = WithTraceID(ctx, id)
+	assert.Equal(t, id.String(), GetTraceIDFromContext(ctx).String())
+}

--- a/trace/http.go
+++ b/trace/http.go
@@ -1,0 +1,12 @@
+package trace
+
+import (
+	"net/http"
+)
+
+// GetTraceIDFromHTTPRequest attempts to return a trace ID read from the @r
+// http request by obtaining the value in the `X-TRACEID` http header field.
+func GetTraceIDFromHTTPRequest(r *http.Request) ID {
+	s := r.Header.Get("X-TRACEID")
+	return Decode([]byte(s))
+}

--- a/trace/traceid.go
+++ b/trace/traceid.go
@@ -1,0 +1,113 @@
+package trace
+
+import (
+	"bytes"
+	crand "crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"math/rand"
+	"sync"
+)
+
+// Generator is a interface to generate trace ids
+type Generator interface {
+	NewTraceID() ID
+}
+
+var traceIDGen Generator
+
+func init() {
+	gen := &defaultIDGenerator{}
+	var rngSeed int64
+	for _, p := range []interface{}{
+		&rngSeed, &gen.traceIDAdd,
+	} {
+		binary.Read(crand.Reader, binary.LittleEndian, p)
+	}
+	gen.traceIDRand = rand.New(rand.NewSource(rngSeed))
+	traceIDGen = gen
+}
+
+// ID is an unique identifier (trace id) that can be use to identify
+// one or more requests between distinct systems. It is a random-generated
+// 16 bytes word, encoded as hexadecimal characters when in string format.
+type ID [16]byte
+
+// String will return the ID as 32 hexadecimal characters string
+func (id ID) String() string {
+	return hex.EncodeToString(id[:])
+}
+
+// UnmarshalJSON parses an ID from a json. The ID is expected to a
+// 32 hexadecimal characters string. This operation is case-insensitive.
+func (id *ID) UnmarshalJSON(b []byte) error {
+	b = bytes.Trim(b, `"`)
+	*id = Decode(b)
+
+	return nil
+}
+
+// Decode turns a set of byte values into a trace ID
+func Decode(b []byte) ID {
+	size := 32
+	if len(b) < size {
+		size = len(b)
+	}
+	b = b[:size]
+
+	var new ID
+	hex.Decode(new[:], b)
+
+	return new
+}
+
+// MarshalJSON converts ID to a 32 hexadecimal characters string.
+func (id ID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.String())
+}
+
+// NewTraceID generates a new random trace id
+func NewTraceID() ID {
+	return traceIDGen.NewTraceID()
+}
+
+// EnsureIDNotEmpty checks if the ID is not empty and return it, else it returns NewTraceID().
+// The empty check follows the same rules as the IDIsEmpty function.
+func EnsureIDNotEmpty(id ID) ID {
+	if IDIsEmpty(id) {
+		return traceIDGen.NewTraceID()
+	}
+	return id
+}
+
+// IDIsEmpty returns true if the @id is nil, empty or composed solely by zeroes.
+func IDIsEmpty(id ID) bool {
+	for _, b := range id {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type defaultIDGenerator struct {
+	sync.Mutex
+
+	traceIDAdd  [2]uint64
+	traceIDRand *rand.Rand
+}
+
+// NewTraceID returns a non-zero trace ID from a randomly-chosen sequence.
+// This function is thread safe.
+func (gen *defaultIDGenerator) NewTraceID() ID {
+	var tid [16]byte
+	// Construct the trace ID from two outputs of traceIDRand, with a constant
+	// added to each half for additional entropy.
+	gen.Lock()
+	defer gen.Unlock()
+
+	binary.LittleEndian.PutUint64(tid[0:8], gen.traceIDRand.Uint64()+gen.traceIDAdd[0])
+	binary.LittleEndian.PutUint64(tid[8:16], gen.traceIDRand.Uint64()+gen.traceIDAdd[1])
+	return ID(tid)
+}

--- a/trace/traceid_test.go
+++ b/trace/traceid_test.go
@@ -1,0 +1,100 @@
+package trace
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceIDGeneration(t *testing.T) {
+	// Should generate random non-empty traceIDs
+	id1 := NewTraceID()
+	id2 := NewTraceID()
+	assert.False(t, IDIsEmpty(id1))
+	assert.False(t, IDIsEmpty(id2))
+	assert.NotEqual(t, id1, id2)
+}
+
+func TestTraceIDMarshall(t *testing.T) {
+	serialized := `{"ID":"5be27e0caf6c932033e5525a0979b074"}`
+	id := ID{91, 226, 126, 12, 175, 108, 147, 32, 51, 229, 82, 90, 9, 121, 176, 116}
+	var serializedMsg struct {
+		ID *ID
+	}
+
+	serializedMsg.ID = &id
+
+	buffer, err := json.Marshal(&serializedMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, serialized, string(buffer))
+}
+
+func TestTraceIDUnmarshall(t *testing.T) {
+	serialized := `{"ID":"5be27e0caf6c932033e5525a0979b074"}`
+	id := ID{91, 226, 126, 12, 175, 108, 147, 32, 51, 229, 82, 90, 9, 121, 176, 116}
+	var serializedMsg struct {
+		ID *ID
+	}
+	err := json.Unmarshal([]byte(serialized), &serializedMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, id, *serializedMsg.ID)
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		description string
+		input       []byte
+		expectedID  ID
+	}{
+		{
+			description: "decoding a correct input",
+			input:       []byte("12345678901234567890123456789012"),
+			expectedID:  ID{0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12},
+		},
+		{
+			description: "decode is case insensitive",
+			input:       []byte("aAbBcCdDeEfFaaAAbbBBccCCddDDeeEE"),
+			expectedID:  ID{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0xaa, 0xaa, 0xbb, 0xbb, 0xcc, 0xcc, 0xdd, 0xdd, 0xee, 0xee},
+		},
+		{
+			description: "smaller input are suffixed with zeros",
+			input:       []byte("1234567890123456789012345678"),
+			expectedID:  ID{0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x00, 0x00},
+		},
+		{
+			description: "larger values are truncated",
+			input:       []byte("12345678901234567890123456789012bebacafe"),
+			expectedID:  ID{0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56, 0x78, 0x90, 0x12},
+		},
+		{
+			description: "decodes goes only up to the first invalid character, after it comes 0's suffix",
+			input:       []byte("1234567890_123456789012345678901"),
+			expectedID:  ID{0x12, 0x34, 0x56, 0x78, 0x90, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+	}
+
+	for _, test := range tests {
+		id := Decode(test.input)
+		assert.Equal(t, test.expectedID, id, "[%s] id differs", test.description)
+	}
+}
+
+func TestTraceIDSerialization_Invalid(t *testing.T) {
+	buffer := []byte("{\"ID\":\"kartoffelpüree mit käse und remoulade\"}")
+	var serializedMsg struct {
+		ID *ID
+	}
+	err := json.Unmarshal(buffer, &serializedMsg)
+	assert.Nil(t, err)
+	assert.True(t, IDIsEmpty(*serializedMsg.ID))
+}
+
+func TestEnsureIDNotEmpty(t *testing.T) {
+	var id ID
+	assert.True(t, IDIsEmpty(id))
+	newID := EnsureIDNotEmpty(id)
+	assert.False(t, IDIsEmpty(newID))
+	sameID := EnsureIDNotEmpty(newID)
+	assert.Equal(t, newID.String(), sameID.String())
+}


### PR DESCRIPTION
I did some adjustments to the comments, trying to make them more clear.
***
The trace package contains the trace.ID type, which can be used as
an trackeable ID between multiple systems. The trace package contains
some utility functions as well, as JSON marshalling and unmarshalling.