### PR TITLE
Adds stakeholder, cuf and nsu packages

### DIFF
--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -2,23 +2,23 @@ package cuf
 
 import "errors"
 
-// Cuf stands for "Codigo da unidade federativa" and it
+// CUF stands for "Codigo da unidade federativa" and it
 // is strongly associated with Stakeholder.
-type Cuf string
+type CUF string
 
-// New validate and returns either (Cuf, nil) if the given cUF
-// is valid or (empty Cuf, error).
-func New(cUF string) (Cuf, error) {
+// New validate and returns either (CUF, nil) if the given cUF
+// is valid or (empty CUF, error).
+func New(cUF string) (CUF, error) {
 	if cUF == "" {
-		return Cuf(""), errors.New("missing cUF")
+		return CUF(""), errors.New("missing cUF")
 	}
 	if isValidUF(cUF) {
-		return Cuf(cUF), nil
+		return CUF(cUF), nil
 	}
-	return Cuf(""), errors.New("invalid cUF")
+	return CUF(""), errors.New("invalid cUF")
 }
 
-func (c Cuf) String() string {
+func (c CUF) String() string {
 	return string(c)
 }
 

--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -1,0 +1,68 @@
+package cuf
+
+import "errors"
+
+// Cuf stands for "Codigo da unidade federativa" and it
+// is strongly associated with Stakeholder.
+type Cuf string
+
+// New validate and returns either (Cuf, nil) if the given cUF
+// is valid or (empty Cuf, error).
+func New(cUF string) (Cuf, error) {
+	if cUF == "" {
+		return Cuf(""), errors.New("missing cUF")
+	}
+	if isValidUF(cUF) {
+		return Cuf(cUF), nil
+	}
+	return Cuf(""), errors.New("invalid cUF")
+}
+
+func (c Cuf) String() string {
+	return string(c)
+}
+
+func isValidUF(uf string) bool {
+	if len(uf) != 2 {
+		return false
+	}
+	switch uf[0] {
+	case '1':
+		switch uf[1] {
+		case '0', '8', '9':
+			return false
+		default:
+			return true
+		}
+	case '2':
+		switch uf[1] {
+		case '0':
+			return false
+		default:
+			return true
+		}
+	case '3':
+		switch uf[1] {
+		case '1', '2', '3', '5':
+			return true
+		default:
+			return false
+		}
+	case '4':
+		switch uf[1] {
+		case '1', '2', '3':
+			return true
+		default:
+			return false
+		}
+	case '5':
+		switch uf[1] {
+		case '0', '1', '2', '3':
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
+	}
+}

--- a/sefaz/cuf/uf_test.go
+++ b/sefaz/cuf/uf_test.go
@@ -43,8 +43,8 @@ func TestIsValidUFSuccess(t *testing.T) {
 	}
 }
 
-func TestCufString(t *testing.T) {
-	cuf := Cuf("35")
+func TestCUFString(t *testing.T) {
+	cuf := CUF("35")
 	assert.Equal(t, "35", cuf.String())
 }
 
@@ -52,25 +52,25 @@ func TestNew(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected Cuf
+		expected CUF
 		err      string
 	}{
 		{
 			name:     "Valid cUF",
 			input:    "35",
-			expected: Cuf("35"),
+			expected: CUF("35"),
 			err:      "",
 		},
 		{
 			name:     "Invalid cUF",
 			input:    "00",
-			expected: Cuf(""),
+			expected: CUF(""),
 			err:      "invalid cUF",
 		},
 		{
 			name:     "Missing cUF",
 			input:    "",
-			expected: Cuf(""),
+			expected: CUF(""),
 			err:      "missing cUF",
 		},
 	}

--- a/sefaz/cuf/uf_test.go
+++ b/sefaz/cuf/uf_test.go
@@ -1,0 +1,87 @@
+package cuf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsValidUFSuccess(t *testing.T) {
+	tests := []struct {
+		str     string
+		isValid bool
+	}{
+		{str: "11", isValid: true}, {str: "12", isValid: true},
+		{str: "13", isValid: true}, {str: "14", isValid: true},
+		{str: "15", isValid: true}, {str: "16", isValid: true},
+		{str: "17", isValid: true}, {str: "21", isValid: true},
+		{str: "22", isValid: true}, {str: "23", isValid: true},
+		{str: "24", isValid: true}, {str: "25", isValid: true},
+		{str: "26", isValid: true}, {str: "27", isValid: true},
+		{str: "28", isValid: true}, {str: "29", isValid: true},
+		{str: "31", isValid: true}, {str: "32", isValid: true},
+		{str: "33", isValid: true}, {str: "35", isValid: true},
+		{str: "41", isValid: true}, {str: "42", isValid: true},
+		{str: "43", isValid: true}, {str: "50", isValid: true},
+		{str: "51", isValid: true}, {str: "52", isValid: true},
+		{str: "53", isValid: true},
+
+		{str: "", isValid: false}, {str: "000", isValid: false},
+		{str: "0", isValid: false}, {str: "00", isValid: false},
+		{str: "1", isValid: false}, {str: "9", isValid: false},
+		{str: "10", isValid: false}, {str: "18", isValid: false},
+		{str: "19", isValid: false}, {str: "20", isValid: false},
+		{str: "30", isValid: false}, {str: "34", isValid: false},
+		{str: "36", isValid: false}, {str: "40", isValid: false},
+		{str: "45", isValid: false}, {str: "49", isValid: false},
+		{str: "54", isValid: false}, {str: "55", isValid: false},
+		{str: "56", isValid: false}, {str: "57", isValid: false},
+		{str: "foo", isValid: false}, {str: "bar", isValid: false},
+	}
+	for _, test := range tests {
+		assert.Equalf(t, test.isValid, isValidUF(test.str), "UF validation failed for uf %s", test.str)
+	}
+}
+
+func TestCufString(t *testing.T) {
+	cuf := Cuf("35")
+	assert.Equal(t, "35", cuf.String())
+}
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Cuf
+		err      string
+	}{
+		{
+			name:     "Valid cUF",
+			input:    "35",
+			expected: Cuf("35"),
+			err:      "",
+		},
+		{
+			name:     "Invalid cUF",
+			input:    "00",
+			expected: Cuf(""),
+			err:      "invalid cUF",
+		},
+		{
+			name:     "Missing cUF",
+			input:    "",
+			expected: Cuf(""),
+			err:      "missing cUF",
+		},
+	}
+
+	for _, test := range tests {
+		cuf, err := New(test.input)
+		if test.err != "" {
+			assert.EqualError(t, err, test.err, "[%s] Error mismatch", test.name)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, test.expected, cuf, "[%s] cUF mismatch", test.name)
+	}
+}

--- a/sefaz/nsu/errors.go
+++ b/sefaz/nsu/errors.go
@@ -3,9 +3,6 @@ package nsu
 import "github.com/arquivei/foundationkit/errors"
 
 var (
-	// ErrCodeNotFound should be returned by repository when the NSU was not found for the given stakeholder
-	ErrCodeNotFound = errors.Code("NSU_NOT_FOUND")
-
 	// ErrCannotParse is returned when a NSU cannot be parsed from a string
 	ErrCannotParse = errors.New("failed to parse nsu from string")
 )

--- a/sefaz/nsu/errors.go
+++ b/sefaz/nsu/errors.go
@@ -1,0 +1,11 @@
+package nsu
+
+import "github.com/arquivei/foundationkit/errors"
+
+var (
+	// ErrCodeNotFound should be returned by repository when the NSU was not found for the given stakeholder
+	ErrCodeNotFound = errors.Code("NSU_NOT_FOUND")
+
+	// ErrCannotParse is returned when a NSU cannot be parsed from a string
+	ErrCannotParse = errors.New("failed to parse nsu from string")
+)

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -1,0 +1,78 @@
+package nsu
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/arquivei/foundationkit/errors"
+)
+
+// NSU is "Número Sequencial Único" and it's an offset used by sefaz to manage the NFes
+type NSU string
+
+func (nsu NSU) String() string {
+	return fmt.Sprintf("%015s", string(nsu))
+}
+
+//MarshalJSON serializes the NSU value as a JSON value
+func (nsu NSU) MarshalJSON() ([]byte, error) {
+	// I don't capture the error here and wraps it with op because it's impossible (probably)
+	// that we can reproduce said error in a unit test and we would have some untestable code.
+	return json.Marshal(nsu.String())
+	// Just for reference, here is the code I previously wrote:
+	/*
+		const op = errors.Op("nsu.MarshalJSON")
+		b, err := json.Marshal(nsu.String())
+		if err != nil {
+			return nil, errors.E(op, err)
+		}
+		return b, nil
+	*/
+}
+
+//UnmarshalJSON deserializes a JSON value into a NSU value
+func (nsu *NSU) UnmarshalJSON(b []byte) error {
+	const op = errors.Op("nsu.UnmarshalJSON")
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	*nsu, err = Parse(s)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	return nil
+}
+
+// Zero is a zero valued NSU.
+const Zero = NSU("000000000000000")
+
+// Parse instantiates a new nsu from @nsu string
+func Parse(nsu string) (NSU, error) {
+	op := errors.Op("nsu.Parse")
+
+	if len(nsu) == 0 {
+		return "", errors.E(op, "nsu is empty")
+	}
+	if len(nsu) > 15 {
+		return "", errors.E(op, "nsu has more than 15 digits")
+	}
+
+	for i := 0; i < len(nsu); i++ {
+		if nsu[i]-'0' > 9 {
+			return "", errors.E(op, ErrCannotParse)
+		}
+	}
+
+	return NSU(fmt.Sprintf("%015s", nsu)), nil
+}
+
+// Compare two NSU's by using this function. NSU's will be compared after
+// being added the padding 0'es. Returns 0 if @source is the same as @compare,
+// 1 if @source is bigger and -1 if @source is smaller
+func Compare(source, compare NSU) int {
+	return strings.Compare(source.String(), compare.String())
+}

--- a/sefaz/nsu/nsu_test.go
+++ b/sefaz/nsu/nsu_test.go
@@ -1,0 +1,109 @@
+package nsu
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNSUStringMethod(t *testing.T) {
+	assert.Equal(t, "000000000000000", NSU("0").String())
+	assert.Equal(t, "000000000000123", NSU("123").String())
+	assert.Equal(t, "123456789012345", NSU("123456789012345").String())
+}
+
+func TestNSUJSONMarshaler(t *testing.T) {
+	n := NSU("123")
+	j, err := n.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`"000000000000123"`), j)
+}
+
+func TestNSUJSONUnmarshaler(t *testing.T) {
+	testcases := []struct {
+		Test     string
+		Input    []byte
+		Expected NSU
+		Err      string
+	}{
+		{
+			Test:     "Valid NSU",
+			Input:    []byte(`"123"`),
+			Expected: NSU("000000000000123"),
+			Err:      "",
+		},
+		{
+			Test:     "Invalid JSON",
+			Input:    []byte(`"123`),
+			Expected: NSU(""),
+			Err:      "nsu.UnmarshalJSON: unexpected end of JSON input",
+		},
+		{
+			Test:     "Invalid NSU",
+			Input:    []byte(`"abc"`),
+			Expected: NSU(""),
+			Err:      "nsu.UnmarshalJSON: nsu.Parse: failed to parse nsu from string",
+		},
+	}
+
+	for _, testcase := range testcases {
+		var output NSU
+		err := output.UnmarshalJSON(testcase.Input)
+		assert.Equal(t, testcase.Expected, output, "[%s] Unexpected output", testcase.Test)
+		if testcase.Err != "" {
+			assert.EqualError(t, err, testcase.Err, "[%s] Unexpected error", testcase.Test)
+		} else {
+			assert.NoError(t, err, "[%s] Unexpected error", testcase.Test)
+		}
+	}
+
+}
+
+func TestParse(t *testing.T) {
+	testcases := []struct {
+		Test     string
+		Input    string
+		Expected NSU
+		Err      string
+	}{
+		{
+			Test:     "Valid NSU",
+			Input:    "123",
+			Expected: NSU("000000000000123"),
+			Err:      "",
+		},
+		{
+			Test:     "Empty NSU",
+			Input:    "",
+			Expected: "",
+			Err:      "nsu.Parse: nsu is empty",
+		},
+		{
+			Test:     "NSU too long",
+			Input:    "0000000000001234",
+			Expected: "",
+			Err:      "nsu.Parse: nsu has more than 15 digits",
+		},
+		{
+			Test:     "Invalid NSU",
+			Input:    "abc",
+			Expected: "",
+			Err:      "nsu.Parse: failed to parse nsu from string",
+		},
+	}
+
+	for _, testcase := range testcases {
+		output, err := Parse(testcase.Input)
+		assert.Equal(t, testcase.Expected, output, "[%s] Unexpected output", testcase.Test)
+		if testcase.Err != "" {
+			assert.EqualError(t, err, testcase.Err, "[%s] Unexpected error", testcase.Test)
+		} else {
+			assert.NoError(t, err, "[%s] Unexpected error", testcase.Test)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	assert.Equal(t, 0, Compare(NSU("000000000000123"), NSU("000000000000123")))
+	assert.Equal(t, 1, Compare(NSU("000000000000123"), NSU("000000000000122")))
+}

--- a/sefaz/stakeholder/check.go
+++ b/sefaz/stakeholder/check.go
@@ -1,0 +1,127 @@
+package stakeholder
+
+import "strconv"
+
+func isDigitOnly(accesskey string) bool {
+	for _, token := range accesskey {
+		if !(token >= '0' && token <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func checkCPF(cpf string) error {
+	if cpf == "" {
+		return ErrCPFEmpty
+	}
+
+	if !isDigitOnly(cpf) {
+		return ErrCPFNotDigitsOnly
+	}
+
+	if len(cpf) != 11 {
+		return ErrCPFInvalidLength
+	}
+
+	i, sum := 10, 0
+
+	for index := 0; index < len(cpf)-2; index++ {
+		pos, err := strconv.Atoi(string(cpf[index]))
+		if err != nil {
+			return err
+		}
+
+		sum += pos * i
+		i--
+	}
+
+	prod := sum * 10
+	mod := prod % 11
+
+	if mod == 10 {
+		mod = 0
+	}
+
+	digit1, err := strconv.Atoi(string(cpf[9]))
+	if err != nil {
+		return err
+	}
+
+	if mod != digit1 {
+		return ErrCPFValidationDigit
+	}
+
+	i, sum = 11, 0
+
+	for index := 0; index < len(cpf)-1; index++ {
+		pos, err := strconv.Atoi(string(cpf[index]))
+		if err != nil {
+			return err
+		}
+
+		sum += pos * i
+		i--
+	}
+
+	prod = sum * 10
+	mod = prod % 11
+
+	if mod == 10 {
+		mod = 0
+	}
+
+	digit2, err := strconv.Atoi(string(cpf[10]))
+	if err != nil {
+		return err
+	}
+
+	if mod != digit2 {
+		return ErrCPFValidationDigit
+	}
+
+	return nil
+}
+
+func checkCNPJ(cnpj string) error {
+	if len(cnpj) == 0 {
+		return ErrCNPJEmpty
+	}
+
+	if !isDigitOnly(cnpj) {
+		return ErrCNPJNotDigitsOnly
+	}
+
+	if len(cnpj) != 14 {
+		return ErrCNPJInvalidLength
+	}
+
+	type validateData struct {
+		multiplier1 uint16
+		multiplier2 uint16
+	}
+
+	data := [14]validateData{
+		{6, 5}, {7, 6}, {8, 7}, {9, 8}, {2, 9}, {3, 2},
+		{4, 3}, {5, 4}, {6, 5}, {7, 6}, {8, 7}, {9, 8},
+		{0, 9}, {0, 0},
+	}
+
+	sumDigit1 := uint16(0)
+	sumDigit2 := uint16(0)
+	for i := 0; i < 14; i++ {
+		c := uint16(cnpj[i]) - '0'
+		if c > 9 {
+			return ErrCNPJNotDigitsOnly
+		}
+
+		sumDigit1 += c * data[i].multiplier1
+		sumDigit2 += c * data[i].multiplier2
+	}
+
+	if uint16(cnpj[12]-'0') != (sumDigit1%11%10) || uint16(cnpj[13]-'0') != (sumDigit2%11%10) {
+		return ErrCNPJValidationDigit
+	}
+
+	return nil
+}

--- a/sefaz/stakeholder/check_test.go
+++ b/sefaz/stakeholder/check_test.go
@@ -1,0 +1,119 @@
+package stakeholder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckDigitOnly(t *testing.T) {
+	tests := []struct {
+		str     string
+		isValid bool
+	}{
+		{
+			str:     "12345678904567890123",
+			isValid: true,
+		},
+		{
+			str:     "11111111111111111111111111111",
+			isValid: true,
+		},
+		{
+			str:     "0125855001-239",
+			isValid: false,
+		},
+		{
+			str:     "1a3456789012345",
+			isValid: false,
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.isValid, isDigitOnly(test.str), "Test case failed [%s]", test.str)
+	}
+}
+
+// The following CPF values were automatically generated using an external tool.
+func TestCheckCPF(t *testing.T) {
+	tests := []struct {
+		name          string
+		cpf           string
+		expectedError error
+	}{
+		{
+			name:          "valid CPF",
+			cpf:           "64287245881",
+			expectedError: nil,
+		},
+		{
+			name:          "invalid CPF format",
+			cpf:           "153.806.664-50",
+			expectedError: ErrCPFNotDigitsOnly,
+		},
+		{
+			name:          "invalid CPF validation digit",
+			cpf:           "64287245883",
+			expectedError: ErrCPFValidationDigit,
+		},
+		{
+			name:          "invalid CPF length",
+			cpf:           "6428724588",
+			expectedError: ErrCPFInvalidLength,
+		},
+		{
+			name:          "empty CPF",
+			cpf:           "",
+			expectedError: ErrCPFEmpty,
+		},
+	}
+	for _, test := range tests {
+		err := checkCPF(test.cpf)
+		assert.Equalf(t, test.expectedError, err, "Test [%s] failed.", test.name)
+	}
+}
+
+func TestCheckCNPJ(t *testing.T) {
+	tests := []struct {
+		cnpj          string
+		expectedError error
+	}{
+		{cnpj: "", expectedError: ErrCNPJEmpty},
+		{cnpj: "1234567890123", expectedError: ErrCNPJInvalidLength},
+		{cnpj: "123456789012345", expectedError: ErrCNPJInvalidLength},
+		{cnpj: "1234/678901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "12345-78901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "a2345678901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "1#345678901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "12@45678901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "123^5678901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "123456 8901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "1234567{901234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "12345678$01234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "123456789~1234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "1234567890_234", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "12345678901m34", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "123456789012a4", expectedError: ErrCNPJNotDigitsOnly},
+		{cnpj: "1234567890123=", expectedError: ErrCNPJNotDigitsOnly},
+
+		// The following CNPJ's values were automatically generated using an external tool.
+		{cnpj: "99859557000140", expectedError: nil},
+		{cnpj: "99859557000149", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "31140936000141", expectedError: nil},
+		{cnpj: "31140936000161", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "79867125000173", expectedError: nil},
+		{cnpj: "79867125000111", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "42885777000120", expectedError: nil},
+		{cnpj: "42885777000199", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "76623396000195", expectedError: nil},
+		{cnpj: "76623396000105", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "49819843000103", expectedError: nil},
+		{cnpj: "49819843000100", expectedError: ErrCNPJValidationDigit},
+		{cnpj: "11664002000100", expectedError: nil},
+		{cnpj: "11664002000111", expectedError: ErrCNPJValidationDigit},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedError, checkCNPJ(test.cnpj), "Test failed for input case [%s]", test.cnpj)
+	}
+}

--- a/sefaz/stakeholder/errors.go
+++ b/sefaz/stakeholder/errors.go
@@ -1,0 +1,29 @@
+package stakeholder
+
+import "github.com/arquivei/foundationkit/errors"
+
+var (
+	// ErrInvalidType is returned when the a Stakeholder has invalid Type value
+	ErrInvalidType = errors.New("invalid stakeholder type")
+	// ErrCPFInvalidLength is returned when a CPF has the wrong size
+	ErrCPFInvalidLength = errors.New("cpf has invalid length")
+	// ErrCPFEmpty is returned when CPF is empty
+	ErrCPFEmpty = errors.New("cpf has empty value")
+	// ErrCPFValidationDigit is returned when either of the validation digit is not valid
+	ErrCPFValidationDigit = errors.New("cpf has wrong validation digit")
+	// ErrCPFNotDigitsOnly is returned when CPF has any char that is not a number
+	ErrCPFNotDigitsOnly = errors.New("cpf must be numbers only")
+
+	// ErrCNPJInvalidLength is returned when a CNPJ has the wrong size
+	ErrCNPJInvalidLength = errors.New("cnpj has invalid length")
+	// ErrCNPJEmpty is returned when CPF is empty
+	ErrCNPJEmpty = errors.New("cnpj has empty value")
+	// ErrCNPJValidationDigit is returned when either of the validation digit is not valid
+	ErrCNPJValidationDigit = errors.New("cnpj has wrong validation digit")
+	// ErrCNPJNotDigitsOnly is returned when CNPJ has any char that is not a number
+	ErrCNPJNotDigitsOnly = errors.New("cnpj must be numbers only")
+)
+
+func newInvalidStakeholderTypeError(t Type) error {
+	return errors.Errorf("invalid stakeholder type: %v", TypeText(t))
+}

--- a/sefaz/stakeholder/stakeholder.go
+++ b/sefaz/stakeholder/stakeholder.go
@@ -1,0 +1,97 @@
+package stakeholder
+
+import (
+	"encoding/json"
+
+	"github.com/arquivei/foundationkit/errors"
+)
+
+// Stakeholder is used to represent a person or company involved
+// in the resources of the system, interested in it's results.
+type Stakeholder string
+
+func (s Stakeholder) String() string {
+	return string(s)
+}
+
+//MarshalJSON serializes the stakeholder value as a JSON value
+func (s Stakeholder) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}
+
+//UnmarshalJSON deserializes a JSON value into a Stakeholder value
+func (s *Stakeholder) UnmarshalJSON(b []byte) error {
+	const op = errors.Op("stakeholder.UnmarshalJSON")
+	var v string
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	*s, err = Parse(v)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	return nil
+}
+
+// GetType returns the stakeholder type
+func GetType(s Stakeholder) Type {
+	return getType(string(s))
+}
+
+func getType(s string) Type {
+	switch len(s) {
+	case 14:
+		return TypeCompany
+	case 11:
+		return TypePerson
+	default:
+		return TypeUnknown
+	}
+}
+
+// Parse attempts to create a stakeholder from it's ID
+func Parse(s string) (Stakeholder, error) {
+	const op = errors.Op("stakeholder.Parse")
+
+	t := getType(s)
+	switch t {
+	case TypeCompany:
+		return NewCNPJ(s)
+	case TypePerson:
+		return NewCPF(s)
+	default:
+		return "", errors.E(op, newInvalidStakeholderTypeError(t))
+	}
+}
+
+// NewCPF creates a new stakeholder with TypePerson
+func NewCPF(cpf string) (Stakeholder, error) {
+	if err := checkCPF(cpf); err != nil {
+		return "", err
+	}
+	return Stakeholder(cpf), nil
+}
+
+// NewCNPJ creates a new stakeholder with TypeCompany
+func NewCNPJ(cnpj string) (Stakeholder, error) {
+	if err := checkCNPJ(cnpj); err != nil {
+		return "", err
+	}
+	return Stakeholder(cnpj), nil
+}
+
+// GetCPFCNPJ returns the CPF or CNPJ of the given stakeholder.
+// Since a stakeholder cannot have both, one of them will be returned
+// empty, or both if stakeholder is of unknown type
+func GetCPFCNPJ(s Stakeholder) (cpf, cnpj string) {
+	switch GetType(s) {
+	case TypePerson:
+		cpf = string(s)
+	case TypeCompany:
+		cnpj = string(s)
+	}
+
+	return
+}

--- a/sefaz/stakeholder/stakeholder_test.go
+++ b/sefaz/stakeholder/stakeholder_test.go
@@ -1,0 +1,119 @@
+package stakeholder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStakeholderString(t *testing.T) {
+	s := Stakeholder("15380666450")
+	assert.Equal(t, "15380666450", s.String())
+}
+
+func TestStakeholderJSONMarshaler(t *testing.T) {
+	s := Stakeholder("15380666450")
+	j, err := s.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`"15380666450"`), j)
+}
+
+func TestStakeholderJSONUnmarshaler(t *testing.T) {
+	testcases := []struct {
+		Test     string
+		Input    []byte
+		Expected Stakeholder
+		Err      string
+	}{
+		{
+			Test:     "Valid CNPJ stakeholder",
+			Input:    []byte(`"49205898000123"`),
+			Expected: Stakeholder("49205898000123"),
+			Err:      "",
+		},
+		{
+			Test:     "Valid CPJ stakeholder",
+			Input:    []byte(`"15380666450"`),
+			Expected: Stakeholder("15380666450"),
+			Err:      "",
+		},
+		{
+			Test:     "Invalid JSON",
+			Input:    []byte(`"15380666450`),
+			Expected: Stakeholder(""),
+			Err:      "stakeholder.UnmarshalJSON: unexpected end of JSON input",
+		},
+		{
+			Test:     "Invalid cnpj",
+			Input:    []byte(`"abc"`),
+			Expected: Stakeholder(""),
+			Err:      "stakeholder.UnmarshalJSON: stakeholder.Parse: invalid stakeholder type: unkown",
+		},
+	}
+
+	for _, testcase := range testcases {
+		var output Stakeholder
+		err := output.UnmarshalJSON(testcase.Input)
+		assert.Equal(t, testcase.Expected, output, "[%s] Unexpected output", testcase.Test)
+		if testcase.Err != "" {
+			assert.EqualError(t, err, testcase.Err, "[%s] Unexpected error", testcase.Test)
+		} else {
+			assert.NoError(t, err, "[%s] Unexpected error", testcase.Test)
+		}
+	}
+
+}
+
+func TestNewCPF(t *testing.T) {
+	sh, err := NewCPF("15380666450")
+	assert.NoError(t, err, "success stakeholder")
+	assert.Equal(t, TypePerson, GetType(sh), "success stakeholder type")
+
+	sh, err = NewCPF("abc")
+	assert.Error(t, err, "fail stakeholder")
+	assert.Equal(t, TypeUnknown, GetType(sh), "fail stakeholder type")
+}
+
+func TestNewCNPJ(t *testing.T) {
+	sh, err := NewCNPJ("49205898000123")
+	assert.NoError(t, err, "success stakeholder")
+	assert.Equal(t, TypeCompany, GetType(sh), "success stakeholder type")
+
+	sh, err = NewCNPJ("abc")
+	assert.Error(t, err, "fail stakeholder")
+	assert.Equal(t, TypeUnknown, GetType(sh), "fail stakeholder type")
+}
+
+func TestGetCPFCNPJ(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        Stakeholder
+		expectedCpf  string
+		expectedCnpj string
+	}{
+		{
+			name:         "Valid CPF",
+			input:        Stakeholder("15380666450"),
+			expectedCpf:  "15380666450",
+			expectedCnpj: "",
+		},
+		{
+			name:         "Valid CNPJ",
+			input:        Stakeholder("49205898000123"),
+			expectedCpf:  "",
+			expectedCnpj: "49205898000123",
+		},
+		{
+			name:         "Invalid stakeholder",
+			input:        Stakeholder("abc"),
+			expectedCpf:  "",
+			expectedCnpj: "",
+		},
+	}
+
+	for _, test := range tests {
+		cpf, cnpj := GetCPFCNPJ(test.input)
+		assert.Equal(t, test.expectedCpf, cpf, "[%s] CPF mismatch")
+		assert.Equal(t, test.expectedCnpj, cnpj, "[%s] CNPJ mismatch")
+	}
+}

--- a/sefaz/stakeholder/type.go
+++ b/sefaz/stakeholder/type.go
@@ -1,0 +1,32 @@
+package stakeholder
+
+import "strconv"
+
+// Type is a strong type to classify a Stakeholder
+type Type int
+
+const (
+	// NOTE : DO NOT REORDER OR DELETE VALUES
+	// Type values are being used on serialization and deserialization of
+	// messages
+
+	// TypeUnknown is the default value, and usually means an error
+	TypeUnknown Type = iota
+	// TypePerson is used to represent 'Pessoa Fisica'
+	TypePerson
+	// TypeCompany is used to represent 'Pessoa Juridica'
+	TypeCompany
+)
+
+// TypeText returns the stakeholder type as a text
+func TypeText(t Type) string {
+	switch t {
+	case TypePerson:
+		return "cpf"
+	case TypeCompany:
+		return "cnpj"
+	case TypeUnknown:
+		return "unkown"
+	}
+	return "unexpected: " + strconv.Itoa(int(t))
+}

--- a/sefaz/stakeholder/type_test.go
+++ b/sefaz/stakeholder/type_test.go
@@ -1,0 +1,39 @@
+package stakeholder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    Type
+		expected string
+	}{
+		{
+			name:     "CPF",
+			input:    TypePerson,
+			expected: "cpf",
+		},
+		{
+			name:     "CNPJ",
+			input:    TypeCompany,
+			expected: "cnpj",
+		},
+		{
+			name:     "Unkown",
+			input:    TypeUnknown,
+			expected: "unkown",
+		},
+		{
+			name:     "Unmapped value",
+			input:    7,
+			expected: "unexpected: 7",
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.expected, TypeText(test.input), "[%s] Failed to check type text", test.name)
+	}
+}


### PR DESCRIPTION
Added some common types used when dealing with sefaz. All three packages were
created inside the sefaz package.

Package stakeholder

Stakeholder is a type that represents a stakeholder in a DFe or an sefaz
interaction. It could be a CPF (Pessoa Física) or a CNPJ (Pessoa Jurídica). The
package contains validators and json marshalers

Package NSU

NSU is a number used by sefaz's dfe distribution service. It's an offset to
request new DFes from sefaz and we store this value alongside with the
documents.

Package cUF

The cUF is the official  brazilian state codes. This package provides validation
and serialziation.