### PR TITLE
Change numeric representation of NSU from int to uint64

### DIFF
--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -84,19 +84,19 @@ func MustParse(s string) NSU {
 	return must(Parse(s))
 }
 
-// ParseInt parses an integer into an NSU
-func ParseInt(nsu uint64) (NSU, error) {
+// ParseUint64 parses an integer into an NSU
+func ParseUint64(nsu uint64) (NSU, error) {
 	return Parse(strconv.FormatInt(int64(nsu), 10))
 }
 
-// MustParseInt parses an integer into an NSU
-func MustParseInt(nsu uint64) NSU {
-	return must(ParseInt(nsu))
+// MustParseUint64 parses an integer into an NSU
+func MustParseUint64(nsu uint64) NSU {
+	return must(ParseUint64(nsu))
 }
 
-// AsInt converts a NSU into an Integer. This function panics if the NSU is not an integer
-func AsInt(nsu NSU) uint64 {
-	const op = errors.Op("nsu.AsInt")
+// AsUint64 converts a NSU into an Integer. This function panics if the NSU is not an integer
+func AsUint64(nsu NSU) uint64 {
+	const op = errors.Op("nsu.AsUint64")
 	i, err := strconv.ParseUint(string(nsu), 10, 64)
 	if err != nil {
 		panic(err)

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -85,19 +85,19 @@ func MustParse(s string) NSU {
 }
 
 // ParseInt parses an integer into an NSU
-func ParseInt(nsu int) (NSU, error) {
-	return Parse(strconv.Itoa(nsu))
+func ParseInt(nsu uint64) (NSU, error) {
+	return Parse(strconv.FormatInt(int64(nsu), 10))
 }
 
 // MustParseInt parses an integer into an NSU
-func MustParseInt(nsu int) NSU {
+func MustParseInt(nsu uint64) NSU {
 	return must(ParseInt(nsu))
 }
 
 // AsInt converts a NSU into an Integer. This function panics if the NSU is not an integer
-func AsInt(nsu NSU) int {
+func AsInt(nsu NSU) uint64 {
 	const op = errors.Op("nsu.AsInt")
-	i, err := strconv.Atoi(string(nsu))
+	i, err := strconv.ParseUint(string(nsu), 10, 64)
 	if err != nil {
 		panic(err)
 	}

--- a/sefaz/nsu/nsu_test.go
+++ b/sefaz/nsu/nsu_test.go
@@ -138,9 +138,9 @@ func TestAsInt(t *testing.T) {
 	for _, testcase := range testcases {
 		var output uint64
 		if testcase.Panics {
-			assert.Panics(t, func() { output = AsInt(testcase.Input) })
+			assert.Panics(t, func() { output = AsUint64(testcase.Input) })
 		} else {
-			output = AsInt(testcase.Input)
+			output = AsUint64(testcase.Input)
 		}
 		assert.Equal(t, testcase.Expected, output, "[%s] Unexpected output", testcase.Test)
 	}

--- a/sefaz/nsu/nsu_test.go
+++ b/sefaz/nsu/nsu_test.go
@@ -113,7 +113,7 @@ func TestAsInt(t *testing.T) {
 	testcases := []struct {
 		Test     string
 		Input    NSU
-		Expected int
+		Expected uint64
 		Panics   bool
 	}{
 		{
@@ -136,7 +136,7 @@ func TestAsInt(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		var output int
+		var output uint64
 		if testcase.Panics {
 			assert.Panics(t, func() { output = AsInt(testcase.Input) })
 		} else {


### PR DESCRIPTION
NSU's can have, according to Sefaz, up to 15 digits. The `int` type of Go, however, can be `int32` on 32-bit architectures. 32-bit numbers comprise up to 10 digits length (5 less than Sefaz specification).
Also, NSU's are positive integers. Therefore, the most appropriate type for its numeric representation is `uint64`.