### PR TITLE
Adds zerolog marhsaler for nsu and cuf types

### DIFF
--- a/sefaz/cuf/zerolog.go
+++ b/sefaz/cuf/zerolog.go
@@ -1,0 +1,10 @@
+package cuf
+
+import "github.com/rs/zerolog"
+
+// MarshalZerologObject implements the zerolog marshaler so it can be logged using:
+// log.With().EmbededObject(cuf).Msg("Some message")
+func (c CUF) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Str("cuf", c.String())
+}

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -96,7 +96,6 @@ func MustParseUint64(nsu uint64) NSU {
 
 // AsUint64 converts a NSU into an Integer. This function panics if the NSU is not an integer
 func AsUint64(nsu NSU) uint64 {
-	const op = errors.Op("nsu.AsUint64")
 	i, err := strconv.ParseUint(string(nsu), 10, 64)
 	if err != nil {
 		panic(err)

--- a/sefaz/nsu/zerolog.go
+++ b/sefaz/nsu/zerolog.go
@@ -1,0 +1,10 @@
+package nsu
+
+import "github.com/rs/zerolog"
+
+// MarshalZerologObject implements the zerolog marshaler so it can be logged using:
+// log.With().EmbededObject(nsu).Msg("Some message")
+func (n NSU) MarshalZerologObject(e *zerolog.Event) {
+	e.
+		Str("nsu", n.String())
+}


### PR DESCRIPTION
Adds the log marshaler interface of zerolog to the nsu and cuf types so that
they can be logged as an EmbededObject.