### PR TITLE
Adds config setup to app package

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/omeid/uconfig"
+	"github.com/rs/zerolog/log"
+)
+
+// ConfigFilename is the filename of the config file automatically loaded by SetupConfig
+var ConfigFilename = "config.json"
+
+// SetupConfig loads the configuration in the given struct. In case of error, prints help and exit application.
+func SetupConfig(config interface{}) {
+	files := make(uconfig.Files)
+	if fileExists(ConfigFilename) {
+		files[ConfigFilename ] = json.Unmarshal
+	}
+
+	c, err := uconfig.Classic(config, files)
+	if err != nil {
+		if c != nil {
+			c.Usage()
+		}
+		if isErrHelpRequested(err) {
+			os.Exit(0)
+		}
+		log.Fatal().Err(err).Msg("Failed to setup config")
+	}
+}
+
+func isErrHelpRequested(err error) bool {
+	return err != nil && err.Error() == "flag: help requested"
+}
+
+func fileExists(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !stat.IsDir()
+}


### PR DESCRIPTION
Adds a public functions SetupConfig that loads configuration from command line,
environment and/or file into a given struct.

The filename can be configured by changing the ConfigFilename variable. It is
set to config.json by default.

If the setup fails, the program ends with an error.