### PR TITLE
Revert `panic` from `CUF.String()` 

### DIFF
--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -37,7 +37,7 @@ func MustNew(uf string) CUF {
 
 func (c CUF) String() string {
 	if !c.initialized {
-		panic("CUF not initialized")
+		return ""
 	}
 	return strconv.Itoa(int(c.value))
 }

--- a/sefaz/cuf/uf_test.go
+++ b/sefaz/cuf/uf_test.go
@@ -156,10 +156,9 @@ func TestMustNew(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	assert.Panics(t, func() {
-		d := CUF{}
-		_ = d.String()
-	}, "CUF not initialized")
+	assert.Equal(t, "", CUF{}.String())
+	assert.Equal(t, "35", MustNew("35").String())
+
 }
 
 func TestMarshalJSON_WithError(t *testing.T) {


### PR DESCRIPTION
Some dependencies are deeply attached to the behavior of  `.String()`
of a not initialized CUF be an empty string.  Use `panic` would imply many
refactorings in other projects. For now, it's better to revert the last PR change.