### PR TITLE
Change `MarshalZerologObject` `panic` behavior

### DIFF
--- a/sefaz/cuf/zerolog.go
+++ b/sefaz/cuf/zerolog.go
@@ -5,6 +5,9 @@ import "github.com/rs/zerolog"
 // MarshalZerologObject implements the zerolog marshaler so it can be logged using:
 // log.With().EmbededObject(cuf).Msg("Some message")
 func (c CUF) MarshalZerologObject(e *zerolog.Event) {
-	e.
-		Str("cuf", c.String())
+	var result string
+	if c.initialized {
+		result = c.String()
+	}
+	e.Str("cuf", result)
 }


### PR DESCRIPTION
When we are serializing a `CUF` we are converting it to a string. An empty or a nil CUF value,  therefore, should produce an empty string.