### PR TITLE
Fix trace package usage at HTTP layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
+	github.com/oklog/ulid v1.3.1
 	github.com/omeid/uconfig v0.0.0-20191124031631-f52a35b0fc4f
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
+github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/omeid/uconfig v0.0.0-20191124031631-f52a35b0fc4f h1:jmos3lCTMlOkDrya6sVnqDSUuxGZ9YXp0NPRtOn/m08=
 github.com/omeid/uconfig v0.0.0-20191124031631-f52a35b0fc4f/go.mod h1:pZndivybprlUQzGeVFfjJv95PDjmmYKgkaB2ren4M/k=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -154,6 +156,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1 h1:QzqyMA1tlu6CgqCDUtU9V+ZKhLFT2dkJuANu5QaxI3I=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/trace/context.go
+++ b/trace/context.go
@@ -48,6 +48,13 @@ func GetIDFromContext(ctx context.Context) ID {
 	return GetTraceFromContext(ctx).ID
 }
 
+// WithTraceAndLabels returns the @parent context with the Trace @trace
+// and the labels @labels
+func WithTraceAndLabels(parent context.Context, trace Trace, labels map[string]string) context.Context {
+	parent = WithTrace(parent, trace)
+	return withLabels(parent, labels)
+}
+
 //
 // [DEPRECATED]
 //

--- a/trace/context.go
+++ b/trace/context.go
@@ -11,8 +11,7 @@ type contextKeyType int
 const (
 	contextKeyTrace contextKeyType = iota
 	contextKeyLabels
-	// [DEPRECATED]
-	contextKeyTraceID
+	contextKeyTraceID // [DEPRECATED] Only used in Deprecated Methods
 )
 
 // WithTrace returns the @parent context with the Trace @trace
@@ -55,18 +54,16 @@ func WithTraceAndLabels(parent context.Context, trace Trace, labels map[string]s
 	return withLabels(parent, labels)
 }
 
-//
-// [DEPRECATED]
-//
-
 // WithTraceID instantiates a new child context from @parent with the
 // given @traceID value set
+// [DEPRECATED] Should use WithTrace instead
 func WithTraceID(parent context.Context, traceID ID) context.Context {
 	return context.WithValue(parent, contextKeyTraceID, traceID)
 }
 
 // GetTraceIDFromContext returns the trace ID set in the context, if any,
 // or an empty trace id if none is set
+// [DEPRECATED] Should use GetTraceFromContext instead
 func GetTraceIDFromContext(ctx context.Context) ID {
 	if id, ok := ctx.Value(contextKeyTraceID).(ID); ok {
 		return id

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -31,6 +31,50 @@ func TestTraceOperations(t *testing.T) {
 	assert.Equal(t, *trace.ProbabilitySample, ps)
 }
 
+func TestTraceAndLabelsOperations(t *testing.T) {
+	ctx := context.Background()
+	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
+	assert.Nil(t, nil, getLabelsFromContext(ctx))
+
+	ps := 0.5
+	ctx = WithTraceAndLabels(ctx, newTrace(ps), map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
+
+	trace := GetTraceFromContext(ctx)
+	assert.False(t, IDIsEmpty(trace.ID))
+	assert.Equal(t, *trace.ProbabilitySample, ps)
+
+	labels := getLabelsFromContext(ctx)
+	for key, value := range labels {
+		switch key {
+		case "k1":
+			assert.Equal(t, "v1", value)
+		case "k2":
+			assert.Equal(t, "v2", value)
+		default:
+			assert.FailNow(t, "none key is valid")
+		}
+	}
+}
+
+func TestTraceAndLabelsOperations_LabelsNil(t *testing.T) {
+	ctx := context.Background()
+	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
+	assert.Nil(t, nil, getLabelsFromContext(ctx))
+
+	ps := 0.5
+	ctx = WithTraceAndLabels(ctx, newTrace(ps), nil)
+
+	trace := GetTraceFromContext(ctx)
+	assert.False(t, IDIsEmpty(trace.ID))
+	assert.Equal(t, *trace.ProbabilitySample, ps)
+
+	labels := getLabelsFromContext(ctx)
+	assert.Nil(t, labels)
+}
+
 func TestLabelsOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.Nil(t, nil, getLabelsFromContext(ctx))

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -28,13 +28,13 @@ func TestTraceOperations(t *testing.T) {
 	trace := GetTraceFromContext(ctx)
 
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, *trace.ProbabilitySample, ps)
+	assert.Equal(t, ps, *trace.ProbabilitySample)
 }
 
 func TestTraceAndLabelsOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
-	assert.Nil(t, nil, getLabelsFromContext(ctx))
+	assert.Nil(t, getLabelsFromContext(ctx))
 
 	ps := 0.5
 	ctx = WithTraceAndLabels(ctx, newTrace(ps), map[string]string{
@@ -44,7 +44,7 @@ func TestTraceAndLabelsOperations(t *testing.T) {
 
 	trace := GetTraceFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, *trace.ProbabilitySample, ps)
+	assert.Equal(t, ps, *trace.ProbabilitySample)
 
 	labels := getLabelsFromContext(ctx)
 	for key, value := range labels {
@@ -62,14 +62,14 @@ func TestTraceAndLabelsOperations(t *testing.T) {
 func TestTraceAndLabelsOperations_LabelsNil(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
-	assert.Nil(t, nil, getLabelsFromContext(ctx))
+	assert.Nil(t, getLabelsFromContext(ctx))
 
 	ps := 0.5
 	ctx = WithTraceAndLabels(ctx, newTrace(ps), nil)
 
 	trace := GetTraceFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, *trace.ProbabilitySample, ps)
+	assert.Equal(t, ps, *trace.ProbabilitySample)
 
 	labels := getLabelsFromContext(ctx)
 	assert.Nil(t, labels)
@@ -77,7 +77,7 @@ func TestTraceAndLabelsOperations_LabelsNil(t *testing.T) {
 
 func TestLabelsOperations(t *testing.T) {
 	ctx := context.Background()
-	assert.Nil(t, nil, getLabelsFromContext(ctx))
+	assert.Nil(t, getLabelsFromContext(ctx))
 
 	ctx = withLabels(ctx, map[string]string{
 		"k1": "v1",
@@ -85,22 +85,11 @@ func TestLabelsOperations(t *testing.T) {
 	})
 
 	labels := getLabelsFromContext(ctx)
-	for key, value := range labels {
-		switch key {
-		case "k1":
-			assert.Equal(t, "v1", value)
-		case "k2":
-			assert.Equal(t, "v2", value)
-		default:
-			assert.FailNow(t, "none key is valid")
-		}
-	}
+	assert.Equal(t, "v1", labels["k1"])
+	assert.Equal(t, "v2", labels["k2"])
 }
 
-//
-// [DEPRECATED]
-//
-
+// [DEPRECATED] Testing a Deprecated Methods
 func TestTraceIDContextOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetTraceIDFromContext(ctx)))

--- a/trace/http.go
+++ b/trace/http.go
@@ -14,19 +14,9 @@ const (
 	headerProbabilitySample = "X-PROBABILITYSAMPLE"
 )
 
-// WithTraceFromHTTPRequest returns a context with a Trace using the
-// trace ID and the probability sample get from the header of @r.
-// This method also put @labels in the returned context.
-func WithTraceFromHTTPRequest(ctx context.Context, r *http.Request, labels map[string]string) context.Context {
-	trace := getTraceFromHTTRequest(r)
-	ctx = WithTrace(ctx, trace)
-	if labels != nil {
-		ctx = withLabels(ctx, labels)
-	}
-	return ctx
-}
-
-func getTraceFromHTTRequest(r *http.Request) Trace {
+// GetTraceFromHTTRequest returns a Trace using the trace
+// ID and the probability sample get from the header of @r
+func GetTraceFromHTTRequest(r *http.Request) Trace {
 	idStr := r.Header.Get(headerTraceID)
 	id := decode([]byte(idStr))
 

--- a/trace/http.go
+++ b/trace/http.go
@@ -68,12 +68,9 @@ func SetTraceInHTTPResponse(trace Trace, response http.ResponseWriter) {
 	return
 }
 
-//
-// [DEPRECATED]
-//
-
 // GetTraceIDFromHTTPRequest attempts to return a trace ID read from the @r
 // http request by obtaining the value in the `X-TRACEID` http header field.
+// [DEPRECATED] Should use GetTraceFromHTTRequest instead
 func GetTraceIDFromHTTPRequest(r *http.Request) ID {
 	s := r.Header.Get("X-TRACEID")
 	return decode([]byte(s))

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -167,10 +167,7 @@ func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
 	assert.Equal(t, "", r.Header.Get(headerProbabilitySample))
 }
 
-//
-// [DEPRECATED]
-//
-
+// [DEPRECATED] Testing a Deprecated Methods
 func TestGetTraceIDFromHTTRequest(t *testing.T) {
 	r, err := http.NewRequest("POST", "URL", nil)
 	assert.NoError(t, err)

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -16,7 +16,7 @@ func TestGetTraceFromHTTRequest(t *testing.T) {
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := getTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
@@ -29,7 +29,7 @@ func TestGetTraceFromHTTRequest_ErrorParseProbabilitySample(t *testing.T) {
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5a")
 
-	trace := getTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
@@ -39,7 +39,7 @@ func TestGetTraceFromHTTRequest_WithoutHeader(t *testing.T) {
 	r, err := http.NewRequest("POST", "URL", nil)
 	assert.NoError(t, err)
 
-	trace := getTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Nil(t, trace.ProbabilitySample)
@@ -51,7 +51,7 @@ func TestGetTraceFromHTTRequest_WithoutProbabilitySample(t *testing.T) {
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 
-	trace := getTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
@@ -63,7 +63,7 @@ func TestGetTraceFromHTTRequest_WithoutTraceID(t *testing.T) {
 
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := getTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
@@ -167,52 +167,17 @@ func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
 	assert.Equal(t, "", r.Header.Get(headerProbabilitySample))
 }
 
-func TestWithTraceFromHTTPRequest(t *testing.T) {
+//
+// [DEPRECATED]
+//
+
+func TestGetTraceIDFromHTTRequest(t *testing.T) {
 	r, err := http.NewRequest("POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
-	r.Header.Add(headerProbabilitySample, "0.5")
 
-	ctx := WithTraceFromHTTPRequest(context.Background(), r, map[string]string{
-		"k1": "v1",
-		"k2": "v2",
-	})
+	id := GetTraceIDFromHTTPRequest(r)
 
-	trace := GetTraceFromContext(ctx)
-
-	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
-	assert.Equal(t, 0.5, *trace.ProbabilitySample)
-
-	labels := getLabelsFromContext(ctx)
-	for key, value := range labels {
-		switch key {
-		case "k1":
-			assert.Equal(t, "v1", value)
-		case "k2":
-			assert.Equal(t, "v2", value)
-		default:
-			assert.FailNow(t, "none key is valid")
-		}
-	}
-
-}
-
-func TestWithTraceFromHTTPRequest_NilLabels(t *testing.T) {
-	r, err := http.NewRequest("POST", "URL", nil)
-	assert.NoError(t, err)
-
-	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
-	r.Header.Add(headerProbabilitySample, "0.5")
-
-	ctx := WithTraceFromHTTPRequest(context.Background(), r, nil)
-
-	trace := GetTraceFromContext(ctx)
-
-	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
-	assert.Equal(t, 0.5, *trace.ProbabilitySample)
-
-	labels := getLabelsFromContext(ctx)
-	assert.Nil(t, labels)
-
+	assert.Equal(t, "00000000000000000000000000000019", id.String())
 }


### PR DESCRIPTION
Previously, it was being considered that the method that knows a http.Request is the same as the method that knows the context of the service. However, this is incorrect.

This fix separates the acquisition of Trace from its association in context.