### PR TITLE
Use "ensureTraceNotEmpty" in "WithTrace"

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -16,6 +16,7 @@ const (
 
 // WithTrace returns the @parent context with the Trace @trace
 func WithTrace(parent context.Context, trace Trace) context.Context {
+	trace = ensureTraceNotEmpty(trace)
 	return context.WithValue(parent, contextKeyTrace, trace)
 }
 

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -11,7 +11,8 @@ func TestIDOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetIDFromContext(ctx)))
 
-	trace := newTrace(0)
+	defaultProbabilitySample = 0
+	trace := newTrace()
 	ctx = WithTrace(ctx, trace)
 
 	assert.False(t, IDIsEmpty(GetIDFromContext(ctx)))
@@ -22,13 +23,13 @@ func TestTraceOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
 
-	ps := 0.5
-	ctx = WithTrace(ctx, newTrace(ps))
+	defaultProbabilitySample = 0.5
+	ctx = WithTrace(ctx, newTrace())
 
 	trace := GetTraceFromContext(ctx)
 
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, ps, *trace.ProbabilitySample)
+	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
 }
 
 func TestTraceAndLabelsOperations(t *testing.T) {
@@ -36,15 +37,15 @@ func TestTraceAndLabelsOperations(t *testing.T) {
 	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
 	assert.Nil(t, getLabelsFromContext(ctx))
 
-	ps := 0.5
-	ctx = WithTraceAndLabels(ctx, newTrace(ps), map[string]string{
+	defaultProbabilitySample = 0.5
+	ctx = WithTraceAndLabels(ctx, newTrace(), map[string]string{
 		"k1": "v1",
 		"k2": "v2",
 	})
 
 	trace := GetTraceFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, ps, *trace.ProbabilitySample)
+	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
 
 	labels := getLabelsFromContext(ctx)
 	for key, value := range labels {
@@ -64,12 +65,12 @@ func TestTraceAndLabelsOperations_LabelsNil(t *testing.T) {
 	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
 	assert.Nil(t, getLabelsFromContext(ctx))
 
-	ps := 0.5
-	ctx = WithTraceAndLabels(ctx, newTrace(ps), nil)
+	defaultProbabilitySample = 0.5
+	ctx = WithTraceAndLabels(ctx, newTrace(), nil)
 
 	trace := GetTraceFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
-	assert.Equal(t, ps, *trace.ProbabilitySample)
+	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
 
 	labels := getLabelsFromContext(ctx)
 	assert.Nil(t, labels)

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -84,14 +84,16 @@ func TestSetTraceInHTTPResponse(t *testing.T) {
 }
 
 func TestSetTraceInHTTPResponse_EmptyTrace(t *testing.T) {
+	defaultProbabilitySample = 0.5
 	r := httptest.NewRecorder()
 	SetTraceInHTTPResponse(Trace{}, r)
 
-	assert.Equal(t, "", r.Header().Get(headerTraceID))
-	assert.Equal(t, "", r.Header().Get(headerProbabilitySample))
+	assert.NotEmpty(t, r.Header().Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
 func TestSetTraceInHTTPResponse_EmptyProbabilitySample(t *testing.T) {
+	defaultProbabilitySample = 0.5
 	trace := Trace{
 		ID: decode([]byte("00000000000000000000000000000019")),
 	}
@@ -99,8 +101,8 @@ func TestSetTraceInHTTPResponse_EmptyProbabilitySample(t *testing.T) {
 	r := httptest.NewRecorder()
 	SetTraceInHTTPResponse(trace, r)
 
-	assert.Equal(t, "", r.Header().Get(headerTraceID))
-	assert.Equal(t, "", r.Header().Get(headerProbabilitySample))
+	assert.Equal(t, "00000000000000000000000000000019", r.Header().Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
 func TestSetTraceInHTTPResponse_EmptyTraceID(t *testing.T) {
@@ -112,8 +114,8 @@ func TestSetTraceInHTTPResponse_EmptyTraceID(t *testing.T) {
 	r := httptest.NewRecorder()
 	SetTraceInHTTPResponse(trace, r)
 
-	assert.Equal(t, "", r.Header().Get(headerTraceID))
-	assert.Equal(t, "", r.Header().Get(headerProbabilitySample))
+	assert.NotEmpty(t, r.Header().Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
 func TestSetTraceInHTTPRequest(t *testing.T) {
@@ -132,15 +134,17 @@ func TestSetTraceInHTTPRequest(t *testing.T) {
 }
 
 func TestSetTraceInHTTPRequest_EmptyTrace(t *testing.T) {
+	defaultProbabilitySample = 0.5
 	r, err := http.NewRequest("POST", "URL", nil)
 	assert.NoError(t, err)
 	SetTraceInHTTPRequest(WithTrace(context.Background(), Trace{}), r)
 
-	assert.Equal(t, "", r.Header.Get(headerTraceID))
-	assert.Equal(t, "", r.Header.Get(headerProbabilitySample))
+	assert.NotEmpty(t, r.Header.Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
 func TestSetTraceInHTTPRequest_EmptyProbabilitySample(t *testing.T) {
+	defaultProbabilitySample = 0.5
 	trace := Trace{
 		ID: decode([]byte("00000000000000000000000000000019")),
 	}
@@ -149,8 +153,8 @@ func TestSetTraceInHTTPRequest_EmptyProbabilitySample(t *testing.T) {
 	assert.NoError(t, err)
 	SetTraceInHTTPRequest(WithTrace(context.Background(), trace), r)
 
-	assert.Equal(t, "", r.Header.Get(headerTraceID))
-	assert.Equal(t, "", r.Header.Get(headerProbabilitySample))
+	assert.Equal(t, "00000000000000000000000000000019", r.Header.Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
 func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
@@ -163,8 +167,8 @@ func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
 	assert.NoError(t, err)
 	SetTraceInHTTPRequest(WithTrace(context.Background(), trace), r)
 
-	assert.Equal(t, "", r.Header.Get(headerTraceID))
-	assert.Equal(t, "", r.Header.Get(headerProbabilitySample))
+	assert.NotEmpty(t, r.Header.Get(headerTraceID))
+	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
 // [DEPRECATED] Testing a Deprecated Methods

--- a/trace/span.go
+++ b/trace/span.go
@@ -28,7 +28,6 @@ func (s *Span) End(err error) {
 // Otherwise, the method will create a new span and return it
 func StartSpanWithParent(ctx context.Context, spanNameArgs ...string) (newCtx context.Context, s Span) {
 	t := GetTraceFromContext(ctx)
-	ctx = createTraceIfEmpty(ctx, &t, defaultProbabilitySample)
 
 	parent := createSpanContext(t.ID.String(), *t.ProbabilitySample)
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,9 +1,5 @@
 package trace
 
-import (
-	"context"
-)
-
 // Trace represents the informations that should be
 // passed through systems
 type Trace struct {
@@ -16,17 +12,23 @@ type Trace struct {
 	ProbabilitySample *float64
 }
 
-func newTrace(defaultProbabilitySample float64) Trace {
+func newTrace() Trace {
 	return Trace{
 		ID:                NewTraceID(),
 		ProbabilitySample: &defaultProbabilitySample,
 	}
 }
 
-func createTraceIfEmpty(ctx context.Context, t *Trace, defaultProbabilitySample float64) context.Context {
-	if t == nil || IDIsEmpty(t.ID) || t.ProbabilitySample == nil {
-		*t = newTrace(defaultProbabilitySample)
+func (t Trace) isEmpty() bool {
+	return IDIsEmpty(t.ID) || t.ProbabilitySample == nil
+}
+
+func ensureTraceNotEmpty(t Trace) Trace {
+	if IDIsEmpty(t.ID) {
+		t.ID = NewTraceID()
 	}
-	ctx = WithTrace(ctx, *t)
-	return ctx
+	if t.ProbabilitySample == nil {
+		t.ProbabilitySample = &defaultProbabilitySample
+	}
+	return t
 }

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -16,7 +16,7 @@ type traceTest struct {
 	expectedID                *ID
 }
 
-func TestCreateTraceIfEmpty(t *testing.T) {
+func TestEnsureTraceNotEmpty(t *testing.T) {
 	ps := 1.9
 	newID := NewTraceID()
 
@@ -33,7 +33,7 @@ func TestCreateTraceIfEmpty(t *testing.T) {
 				ProbabilitySample: &ps,
 			},
 			defaultProbabilitySample:  0.5,
-			expectedProbabilitySample: 0.5,
+			expectedProbabilitySample: ps,
 		},
 		{
 			name: "Probability Sample Empty",
@@ -56,7 +56,9 @@ func TestCreateTraceIfEmpty(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ctx := createTraceIfEmpty(context.Background(), &test.trace, test.defaultProbabilitySample)
+		defaultProbabilitySample = test.defaultProbabilitySample
+		test.trace = ensureTraceNotEmpty(test.trace)
+		ctx := WithTrace(context.Background(), test.trace)
 		assertTrace(t, test, "Trace from Test")
 
 		traceFromCtx := GetTraceFromContext(ctx)


### PR DESCRIPTION
If the context has a empty trace, a new one will be created only if a span started. So, if the system do not use a span, a empty trace will remain in context.

This commit use ensureTraceNotEmpty in WithTrace method. Now, every time a trace is put in context, it will be not empty.