### PR TITLE
Adds structure flattening (into string)

### DIFF
--- a/log/flatten.go
+++ b/log/flatten.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Flatten transforms a struct into a flattened string, like: a.b.c: 'val', c.d: 'val'
+// Pointer values will translate into memory addresses
+//
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// !!!!!!!! IMPORTANT SECURITY NOTE !!!!!!!!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+//
+// Flatten will place ALL keys of the given structure on
+// the resulted string. This means that ANY sensitive data
+// in the flattened structure WILL be exposed!
+func Flatten(value interface{}) string {
+	m := flattenPrefixed(value, "")
+	sb := strings.Builder{}
+	for k, v := range m {
+		sb.WriteString(k)
+		sb.WriteString(": ")
+		sb.WriteString(fmt.Sprintf("'%v'", v))
+		sb.WriteString(", ")
+	}
+
+	return strings.Trim(sb.String(), ", ")
+}
+
+func flattenPrefixed(value interface{}, prefix string) map[string]interface{} {
+	m := make(map[string]interface{})
+	flattenPrefixedToResult(value, prefix, m)
+	return m
+}
+
+func flattenPrefixedToResult(value interface{}, prefix string, m map[string]interface{}) {
+	base := ""
+	if prefix != "" {
+		base = prefix + "."
+	}
+
+	original := reflect.ValueOf(value)
+	kind := original.Kind()
+	if kind == reflect.Ptr || kind == reflect.Interface {
+		original = reflect.Indirect(original)
+		kind = original.Kind()
+	}
+	t := original.Type()
+
+	switch kind {
+	case reflect.Map:
+		if t.Key().Kind() != reflect.String {
+			break
+		}
+		for _, childKey := range original.MapKeys() {
+			childValue := original.MapIndex(childKey)
+			flattenPrefixedToResult(childValue.Interface(), base+childKey.String(), m)
+		}
+	case reflect.Struct:
+		for i := 0; i < original.NumField(); i++ {
+			childValue := original.Field(i)
+			childKey := t.Field(i).Name
+			flattenPrefixedToResult(childValue.Interface(), base+childKey, m)
+		}
+	default:
+		if prefix != "" {
+			m[prefix] = value
+		}
+	}
+}

--- a/log/flatten_test.go
+++ b/log/flatten_test.go
@@ -1,0 +1,42 @@
+package log
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// Due to the non-determinism nature functions , it is really hard to produce
+// more complex tests, as the fields are not guaranteed to be in any order
+func TestFlatten(t *testing.T) {
+	structA := struct {
+		FooA string
+	}{
+		FooA: "abC%#1s",
+	}
+	expectedFlattenA := `FooA: 'abC%#1s'`
+	assert.Equal(t, expectedFlattenA, Flatten(structA), "test failed for struct A")
+
+	structB := struct {
+		FooB int
+	}{
+		FooB: 2,
+	}
+	expectedFlattenB := `FooB: '2'`
+	assert.Equal(t, expectedFlattenB, Flatten(structB), "test failed for struct B")
+
+	structC := struct {
+		FooC bool
+	}{
+		FooC: false,
+	}
+	expectedFlattenC := `FooC: 'false'`
+	assert.Equal(t, expectedFlattenC, Flatten(structC), "test failed for struct C")
+
+	structD := struct {
+		FooD interface{}
+	}{
+		FooD: "5",
+	}
+	expectedFlattenD := `FooD: '5'`
+	assert.Equal(t, expectedFlattenD, Flatten(structD), "test failed for struct D")
+}


### PR DESCRIPTION
Flattening structures has proven to be useful when logging
complex structures.

!!!!!!!! IMPORTANT SECURITY NOTE !!!!!!!!

Flatten will place ALL keys of the given structure on
the resulted string. This means that ANY sensitive data
in the flattened structure WILL be exposed!