### PR TITLE
Modifies log/flatten to not log secrets

### DIFF
--- a/log/flatten.go
+++ b/log/flatten.go
@@ -60,6 +60,11 @@ func flattenPrefixedToResult(value interface{}, prefix string, m map[string]inte
 		}
 	case reflect.Struct:
 		for i := 0; i < original.NumField(); i++ {
+			isSecretStr, hasTag := t.Field(i).Tag.Lookup("secret")
+			if hasTag && isSecretStr == "true" {
+				continue
+			}
+
 			childValue := original.Field(i)
 			childKey := t.Field(i).Name
 			flattenPrefixedToResult(childValue.Interface(), base+childKey, m)

--- a/log/flatten_test.go
+++ b/log/flatten_test.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Due to the non-determinism nature functions , it is really hard to produce
@@ -39,4 +40,14 @@ func TestFlatten(t *testing.T) {
 	}
 	expectedFlattenD := `FooD: '5'`
 	assert.Equal(t, expectedFlattenD, Flatten(structD), "test failed for struct D")
+
+	structE := struct {
+		FooE1 interface{}
+		FooE2 interface{} `secret:"true"`
+	}{
+		FooE1: "5",
+		FooE2: "q1w2e3",
+	}
+	expectedFlattenE := `FooE1: '5'`
+	assert.Equal(t, expectedFlattenE, Flatten(structE), "test failed for struct E")
 }


### PR DESCRIPTION
If the configs has a sensitive data, it will be logged if using the
Flatten method.

Adds a check for the "secret" tag. If a struct field has this tag with
the value "true" (eg: Password `secret:"true"`), it is not logged.