### PR TITLE
Changes app's shutdown to use priority queue

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -116,7 +116,7 @@ func (a *App) shutdownAllHandlers(ctx context.Context) chan error {
 	go func() {
 		defer close(done)
 		for a.shutdownHandlers.Len() > 0 {
-			h := heap.Pop(&a.shutdownHandlers).(*shutdownHandler)
+			h := heap.Pop(&a.shutdownHandlers).(*ShutdownHandler)
 			if ctx.Err() != nil {
 				done <- errors.E(op, ctx.Err())
 			}
@@ -169,9 +169,12 @@ func (a *App) RunAndWait() {
 }
 
 // RegisterShutdownHandler adds a handler in the end of the list. During shutdown all handlers are executed in the order they were added
-func (a *App) RegisterShutdownHandler(name string, fn ShutdownFunc, options ...interface{}) {
+func (a *App) RegisterShutdownHandler(sh *ShutdownHandler) {
+	if sh.Name == "" {
+		panic("Shutdown handler name must not be an empty string")
+	}
 	if len(a.shutdownHandlers) == 0 {
 		heap.Init(&a.shutdownHandlers)
 	}
-	heap.Push(&a.shutdownHandlers, NewShutdownHandler(name, fn, options...))
+	heap.Push(&a.shutdownHandlers, sh)
 }

--- a/app/default.go
+++ b/app/default.go
@@ -47,11 +47,11 @@ func Shutdown(ctx context.Context) error {
 }
 
 // RegisterShutdownHandler calls the RegisterShutdownHandler from the default app
-func RegisterShutdownHandler(name string, fn ShutdownFunc, options ...interface{}) {
+func RegisterShutdownHandler(sh *ShutdownHandler) {
 	if defaultApp == nil {
 		panic("default app not initialized")
 	}
-	defaultApp.RegisterShutdownHandler(name, fn, options...)
+	defaultApp.RegisterShutdownHandler(sh)
 }
 
 // IsReady returns if the default app is ready (to be used by kubernetes readyness probe)

--- a/app/shutdownhandler.go
+++ b/app/shutdownhandler.go
@@ -1,0 +1,156 @@
+package app
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// ErrorPolicy specifies what should be done when a handler fails
+type ErrorPolicy int
+
+// ShutdownPriority is used to guide the execution of the shutdown handlers
+// during a graceful shutdown. The shutdown is performed from the higher to the lowest
+// priority
+type ShutdownPriority int
+
+const (
+	// ErrorPolicyWarn prints the error as a warning and continues to the next handler. This is the default.
+	ErrorPolicyWarn ErrorPolicy = iota
+	// ErrorPolicyAbort stops the shutdown process and returns an error
+	ErrorPolicyAbort
+	// ErrorPolicyFatal logs the error as Fatal, it means the application will close immediately
+	ErrorPolicyFatal
+	// ErrorPolicyPanic panics if there is an error
+	ErrorPolicyPanic
+)
+
+// ShutdownFunc is a shutdown function that will be executed when the app is shutting down.
+type ShutdownFunc func(context.Context) error
+
+type shutdownHandler struct {
+	Name     string
+	Timeout  time.Duration
+	Policy   ErrorPolicy
+	Priority ShutdownPriority
+
+	Shutdown ShutdownFunc
+	executed bool
+	err      error
+	mu       sync.Mutex
+	index    int
+}
+
+// NewShutdownHandler returns a new
+func NewShutdownHandler(name string, fn ShutdownFunc, options ...interface{}) *shutdownHandler {
+	if name == "" {
+		panic("shutdown handler must have a name")
+	}
+	sh := &shutdownHandler{
+		Name:     name,
+		Shutdown: fn,
+	}
+	for _, o := range options {
+		switch opt := o.(type) {
+		case time.Duration:
+			sh.Timeout = opt
+		case ErrorPolicy:
+			sh.Policy = opt
+		case ShutdownPriority:
+			sh.Priority = opt
+		default:
+			panic(errors.Errorf("invalid shutdown handler option: [%T]%v", o, o))
+		}
+	}
+	return sh
+}
+
+// Execute runs the shutdown functions and handles timeout and error policy
+func (sh *shutdownHandler) Execute(ctx context.Context) error {
+	const op = errors.Op("app.shutdownHandler.Execute")
+
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	// The shutdown should run only once
+	// Future calls will return the result of the first call
+	if sh.executed {
+		return sh.err
+	}
+	sh.executed = true
+
+	// Avoid runnign if the context is already closed
+	if ctx.Err() != nil {
+		sh.err = ctx.Err()
+		return sh.err
+	}
+
+	// Set the configured timeout, if any
+	if sh.Timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, sh.Timeout)
+		defer cancel()
+	}
+
+	// Execute the shutdown function and process the result
+	err := sh.Shutdown(ctx)
+	if err != nil {
+		err = errors.E(op, errors.E(errors.Op(sh.Name), err))
+		switch sh.Policy {
+		case ErrorPolicyWarn:
+			log.Ctx(ctx).Warn().Err(err).Msg("Shutdown handler failed")
+		case ErrorPolicyAbort:
+			sh.err = err
+			// No need for logging here, this will happen latter
+		case ErrorPolicyFatal:
+			log.Ctx(ctx).Fatal().Err(err).Msg("Shutdown handler failed")
+		case ErrorPolicyPanic:
+			panic(err)
+		default:
+			panic(errors.Errorf("invalid error policy: %v", sh.Policy))
+		}
+	}
+
+	log.Ctx(ctx).Info().
+		Str("handler", sh.Name).
+		Int("shutdown_priority", int(sh.Priority)).
+		Msg("Shutdown successfull")
+
+	return sh.err
+}
+
+// shutdownHeap is a heap implementation for the *shutdownHandler type
+type shutdownHeap []*shutdownHandler
+
+func (sq shutdownHeap) Len() int {
+	return len(sq)
+}
+
+func (sq shutdownHeap) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return sq[i].Priority > sq[j].Priority
+}
+
+func (sq shutdownHeap) Swap(i, j int) {
+	sq[i], sq[j] = sq[j], sq[i]
+	sq[i].index, sq[j].index = i, j
+}
+
+func (sq *shutdownHeap) Push(x interface{}) {
+	sh := x.(*shutdownHandler)
+	sh.index = len(*sq)
+	*sq = append(*sq, sh)
+}
+
+func (sq *shutdownHeap) Pop() interface{} {
+	old := *sq
+	n := len(old)
+	sh := old[n-1]
+	old[n-1] = nil
+	sh.index = -1
+	*sq = old[0 : n-1]
+	return sh
+}

--- a/app/shutdownhandler.go
+++ b/app/shutdownhandler.go
@@ -61,7 +61,7 @@ func (sh *ShutdownHandler) Execute(ctx context.Context) error {
 
 	// Avoid runnign if the context is already closed
 	if ctx.Err() != nil {
-		sh.err = ctx.Err()
+		sh.err = errors.E(op, errors.E(errors.Op(sh.Name), ctx.Err()))
 		return sh.err
 	}
 

--- a/app/shutdownhandler_test.go
+++ b/app/shutdownhandler_test.go
@@ -1,0 +1,137 @@
+package app
+
+import (
+	"container/heap"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShutdownhandlerHeap(t *testing.T) {
+	h := shutdownHeap{}
+	heap.Init(&h)
+	assert.Equal(t, h.Len(), 0, "a new heap must be empty")
+
+	assert.Panics(t, func() {
+		heap.Push(&h, nil)
+	}, "Push should panic if value is nil")
+
+	assert.Panics(t, func() {
+		heap.Push(&h, ShutdownHandler{})
+	}, "Push should panic if if value type is not *ShutdownHandler")
+
+	sh1 := &ShutdownHandler{
+		Name:     "sh1",
+		Priority: ShutdownPriority(0),
+	}
+
+	sh2 := &ShutdownHandler{
+		Name:     "sh2",
+		Priority: ShutdownPriority(10),
+	}
+
+	sh3 := &ShutdownHandler{
+		Name:     "sh3",
+		Priority: ShutdownPriority(5),
+	}
+
+	sh4 := &ShutdownHandler{
+		Name:     "sh4",
+		Priority: ShutdownPriority(5),
+	}
+
+	heap.Push(&h, sh1)
+	heap.Push(&h, sh2)
+	heap.Push(&h, sh4)
+	heap.Push(&h, sh3)
+	assert.Equal(t, h.Len(), 4, "heap should have 4 elements")
+
+	p1 := heap.Pop(&h)
+	p2 := heap.Pop(&h)
+	p3 := heap.Pop(&h)
+	p4 := heap.Pop(&h)
+
+	assert.Equal(t, sh1, p4, "sh1 has de lowest priority and must be poped last")
+	assert.Equal(t, sh2, p1, "sh2 has the highest priority and must be poped first")
+	assert.Equal(t, sh3, p3, "sh3 must be poped after sh4 and before sh1")
+	assert.Equal(t, sh4, p2, "sh4 must be poped after sh2 and before sh3")
+
+	assert.Equal(t, h.Len(), 0, "heap should be empty")
+}
+
+func TestShutdownHandlerExecute(t *testing.T) {
+	assert.Panics(t, func() {
+		sh := &ShutdownHandler{}
+		sh.Execute(context.TODO())
+	}, "should panic if Handler is not set")
+
+	sh := &ShutdownHandler{
+		Name: "my_shutdown_handler",
+		Handler: func(context.Context) error {
+			return nil
+		},
+	}
+
+	assert.False(t, sh.executed)
+	assert.NoError(t, sh.err)
+
+	err := sh.Execute(context.TODO())
+	assert.NoError(t, err)
+	assert.NoError(t, sh.err)
+	assert.True(t, sh.executed)
+
+	sh = &ShutdownHandler{
+		Name: "my_failed_shutdown_handler",
+		Handler: func(context.Context) error {
+			return errors.New("my error")
+		},
+		Policy: ErrorPolicyAbort,
+	}
+
+	err = sh.Execute(context.TODO())
+	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: my error")
+
+	err2 := sh.Execute(context.TODO())
+	assert.Equal(t, err, err2, "a second execution of handler should return the first error")
+}
+
+func TestShutdownHandlerExecute_CanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sh := &ShutdownHandler{
+		Name: "my_failed_shutdown_handler",
+		Handler: func(context.Context) error {
+			return errors.New("my error")
+		},
+		Policy: ErrorPolicyAbort,
+	}
+
+	err := sh.Execute(ctx)
+	assert.True(t, sh.executed)
+	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: context canceled")
+}
+
+func TestShutdownHandlerExecute_Timeout(t *testing.T) {
+	sh := &ShutdownHandler{
+		Name: "my_failed_shutdown_handler",
+		Handler: func(ctx context.Context) error {
+			select {
+			case <-time.After(2 * time.Nanosecond):
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+		Policy:  ErrorPolicyAbort,
+		Timeout: time.Nanosecond,
+	}
+
+	ctx := context.Background()
+	err := sh.Execute(ctx)
+	assert.True(t, sh.executed)
+	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: context deadline exceeded")
+}


### PR DESCRIPTION
Previously the shutdown handlers were handled in a slice and were
executed in the order they were added.

Now it was changed to use a container/heap implementation. Each shutdown
handler receives an optional ShutdownPriority option and are processed
from the highest to lowest during a graceful shutdown.

There is no order guarantee for handlers of the same priority.