### PR TITLE
[App] Improves shutdown timeout error messages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -101,7 +101,7 @@ func (a *App) Shutdown(ctx context.Context) error {
 	var err error
 	select {
 	case <-ctx.Done():
-		err = ctx.Err()
+		err = errors.E(op, "shutdown deadline has been reached")
 	case err = <-a.shutdownAllHandlers(ctx):
 	}
 	if err != nil {
@@ -118,7 +118,7 @@ func (a *App) shutdownAllHandlers(ctx context.Context) chan error {
 		for a.shutdownHandlers.Len() > 0 {
 			h := heap.Pop(&a.shutdownHandlers).(*ShutdownHandler)
 			if ctx.Err() != nil {
-				done <- errors.E(op, ctx.Err())
+				done <- errors.E(op, "shutdow deadline has been reached")
 			}
 			if err := h.Execute(ctx); err != nil {
 				done <- errors.E(op, err)

--- a/app/default.go
+++ b/app/default.go
@@ -8,9 +8,9 @@ import (
 var (
 	// DefaultGracePeriod is the default value for the grace period.
 	// During normal shutdown procedures, the shutdown function will wait
-	// this amount of time before actually starting calling the shurdown handlers.
+	// this amount of time before actually starting calling the shutdown handlers.
 	DefaultGracePeriod = 3 * time.Second
-	// DefaultShutdownTimeout is the defualt value for the timeout during shutdown.
+	// DefaultShutdownTimeout is the default value for the timeout during shutdown.
 	DefaultShutdownTimeout = 5 * time.Second
 	// DefaultAdminPort is the default port the app will bind the admin HTTP interface.
 	DefaultAdminPort = "9000"
@@ -18,7 +18,7 @@ var (
 	defaultApp *App
 )
 
-// NewDefaultApp creates and sets the defualt app. The default app is controlled by
+// NewDefaultApp creates and sets the default app. The default app is controlled by
 // public functions in app package
 func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error) {
 	defaultApp, err = New(ctx, DefaultAdminPort, mainLoop)

--- a/app/shutdownhandler.go
+++ b/app/shutdownhandler.go
@@ -31,6 +31,8 @@ const (
 // ShutdownFunc is a shutdown function that will be executed when the app is shutting down.
 type ShutdownFunc func(context.Context) error
 
+// ShutdownHandler is a shutdown structure that allows configuring
+// and storing shutdown information of an orchestrated shutdown flow.
 type ShutdownHandler struct {
 	Name     string
 	Timeout  time.Duration
@@ -59,9 +61,9 @@ func (sh *ShutdownHandler) Execute(ctx context.Context) error {
 	}
 	sh.executed = true
 
-	// Avoid runnign if the context is already closed
+	// Avoid running if the context is already closed
 	if ctx.Err() != nil {
-		sh.err = errors.E(op, errors.E(errors.Op(sh.Name), ctx.Err()))
+		sh.err = errors.E(op, errors.E(errors.Op(sh.Name), "skipping handler as deadline has been reached"))
 		return sh.err
 	}
 

--- a/app/shutdownhandler_test.go
+++ b/app/shutdownhandler_test.go
@@ -54,10 +54,10 @@ func TestShutdownhandlerHeap(t *testing.T) {
 	p3 := heap.Pop(&h)
 	p4 := heap.Pop(&h)
 
-	assert.Equal(t, sh1, p4, "sh1 has de lowest priority and must be poped last")
-	assert.Equal(t, sh2, p1, "sh2 has the highest priority and must be poped first")
-	assert.Equal(t, sh3, p3, "sh3 must be poped after sh4 and before sh1")
-	assert.Equal(t, sh4, p2, "sh4 must be poped after sh2 and before sh3")
+	assert.Equal(t, sh1, p4, "sh1 has de lowest priority and must be popped last")
+	assert.Equal(t, sh2, p1, "sh2 has the highest priority and must be popped first")
+	assert.Equal(t, sh3, p3, "sh3 must be popped after sh4 and before sh1")
+	assert.Equal(t, sh4, p2, "sh4 must be popped after sh2 and before sh3")
 
 	assert.Equal(t, h.Len(), 0, "heap should be empty")
 }
@@ -112,7 +112,7 @@ func TestShutdownHandlerExecute_CanceledContext(t *testing.T) {
 
 	err := sh.Execute(ctx)
 	assert.True(t, sh.executed)
-	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: context canceled")
+	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: skipping handler as deadline has been reached")
 }
 
 func TestShutdownHandlerExecute_Timeout(t *testing.T) {
@@ -123,7 +123,7 @@ func TestShutdownHandlerExecute_Timeout(t *testing.T) {
 			case <-time.After(2 * time.Nanosecond):
 				return nil
 			case <-ctx.Done():
-				return ctx.Err()
+				return errors.New("custom handler error on deadline exceeded")
 			}
 		},
 		Policy:  ErrorPolicyAbort,
@@ -133,5 +133,5 @@ func TestShutdownHandlerExecute_Timeout(t *testing.T) {
 	ctx := context.Background()
 	err := sh.Execute(ctx)
 	assert.True(t, sh.executed)
-	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: context deadline exceeded")
+	assert.EqualError(t, err, "app.shutdownHandler.Execute: my_failed_shutdown_handler: custom handler error on deadline exceeded")
 }


### PR DESCRIPTION
The shutdown procedure was using ctx.Err() as an erro messages when
detecting timeouts and deadlines throught the context. Sometimes, these
errors being logged into a log system resulted in readers confusion,
alerting that a service Request was somehow causing a timeout that was
killing the whole service.

The error messages were changed to be more specific and less generic,
in order to reduce the chance of confusion and speed up analysis when
tracking down issues.

Also, fixed some linter errors and executed a spell check tool in the
app package.