### PR TITLE
Add a shutdown call when app finished by itself

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -156,8 +156,10 @@ func (a *App) RunAndWait() {
 		time.Sleep(a.GracePeriod)
 		log.Ctx(a.ctx).Info().Msg("Grace period is over, initiating shutdown procedures...")
 		err = a.Shutdown(ctx)
-	case err = <-errs: // App finished by itself
+	case err = <-errs:
 		a.Ready = false
+		log.Ctx(a.ctx).Info().Msg("App finished by itself, initialing shutdown procedures...")
+		err = a.Shutdown(ctx)
 	}
 	if err == nil {
 		log.Ctx(a.ctx).Info().Msg("App exited")

--- a/app/shutdownhandler.go
+++ b/app/shutdownhandler.go
@@ -31,6 +31,7 @@ const (
 // ShutdownFunc is a shutdown function that will be executed when the app is shutting down.
 type ShutdownFunc func(context.Context) error
 
+// ShutdownHandler is used to register a shutdown function
 type ShutdownHandler struct {
 	Name     string
 	Timeout  time.Duration


### PR DESCRIPTION
When a app.mainLoop ends by itself, only the Ready status is set to
false, unlike the others cases, where the shutdown method is called. The
goduck workers ends a lot by itself and they need a propely shutdown.

Adds a shutdown call in case when the app ends by itself.