### PR TITLE
Adds EqualCode and SameCode error functions to the errors package

### DIFF
--- a/errors/code.go
+++ b/errors/code.go
@@ -13,8 +13,9 @@ const (
 	ErrorCodeEmpty = Code("")
 )
 
-// GetErrorCode returns the error code. If the error doesn't contains an error code, returns ErrorCodeEmpty.
-func GetErrorCode(err error) Code {
+// GetCode returns the error code. If the error doesn't contains
+// an error code, returns ErrorCodeEmpty
+func GetCode(err error) Code {
 	for {
 		e, ok := err.(Error)
 		if !ok {
@@ -27,4 +28,26 @@ func GetErrorCode(err error) Code {
 	}
 
 	return ErrorCodeEmpty
+}
+
+// GetErrorCode returns the error code. If the error doesn't contains an error code, returns ErrorCodeEmpty.
+//
+// Deprecated: use GetCode instead.
+func GetErrorCode(err error) Code {
+	return GetCode(err)
+}
+
+// EqualsCode returns true if @lCode and @rCode holds the same value, and
+// false otherwise
+func EqualsCode(lCode, rCode Code) bool {
+	return (lCode == rCode)
+}
+
+// SameCode returns true if @lError and @rError holds error codes with the
+// same value, and false otherwise. If one or both errors have no code, SameCode
+// will return false.
+func SameCode(lError, rError error) bool {
+	lCode := GetCode(lError)
+	rCode := GetCode(rError)
+	return (lCode == rCode && lCode != ErrorCodeEmpty)
 }

--- a/errors/code_test.go
+++ b/errors/code_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,4 +24,21 @@ func TestErrorCode_WithoutErrorCode(t *testing.T) {
 	assert.Equal(t, ErrorCodeEmpty, GetErrorCode(err))
 
 	assert.Equal(t, ErrorCodeEmpty, GetErrorCode(nil))
+}
+
+func TestEqualsCode(t *testing.T) {
+	assert.True(t, EqualsCode(Code("NO_FOOD"), Code("NO_FOOD")), "same error code")
+	assert.False(t, EqualsCode(Code("RESIDENT_EVIL"), Code("VERONICA")), "different error code")
+	assert.True(t, EqualsCode(ErrorCodeEmpty, ErrorCodeEmpty), "empty error code is the same")
+}
+
+func TestSameCode(t *testing.T) {
+	errWithCodeTalker := E("Metal Gear Solid V: the Phantom Pain", Code("TALKER"))
+	anotherErrWithCodeTalker := E("Metal Gear Solid V: the Phantom Pain (goty)", Code("TALKER"))
+	errWithCodeVeronica := E("Resident Evil", Code("VERONICA"))
+
+	assert.True(t, SameCode(errWithCodeTalker, anotherErrWithCodeTalker), "same code")
+	assert.False(t, SameCode(errWithCodeTalker, errWithCodeVeronica), "different codes")
+	assert.False(t, SameCode(errWithCodeTalker, errors.New("konami")), "right error has no code")
+	assert.False(t, SameCode(errors.New("capcom"), errWithCodeVeronica), "left error has no code")
 }


### PR DESCRIPTION
The EqualCode and SameCode functions have been added, as they make
error handling a bit easier to read in some situations. Also, a
GetCode function has been added, to follow the same naming pattern
as GetSeverity.