### PR TITLE
Adds stale middleware

### DIFF
--- a/gokitmiddlewares/stalemiddleware/config.go
+++ b/gokitmiddlewares/stalemiddleware/config.go
@@ -8,11 +8,13 @@ import (
 )
 
 type Config struct {
-	Timeout time.Duration
-	Logger  *zerolog.Logger
+	Logger                 *zerolog.Logger
+	MaxTimeBetweenRequests time.Duration
+	StartCheckAfter        time.Duration
 }
 
 var DefaultConfig = Config{
-	Timeout: 60 * time.Second,
-	Logger:  &log.Logger,
+	MaxTimeBetweenRequests: time.Minute,
+	Logger:                 &log.Logger,
+	StartCheckAfter:        10 * time.Second,
 }

--- a/gokitmiddlewares/stalemiddleware/config.go
+++ b/gokitmiddlewares/stalemiddleware/config.go
@@ -1,0 +1,18 @@
+package stalemiddleware
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+type Config struct {
+	Timeout time.Duration
+	Logger  *zerolog.Logger
+}
+
+var DefaultConfig = Config{
+	Timeout: 60 * time.Second,
+	Logger:  &log.Logger,
+}

--- a/gokitmiddlewares/stalemiddleware/middleware.go
+++ b/gokitmiddlewares/stalemiddleware/middleware.go
@@ -1,0 +1,39 @@
+package stalemiddleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/arquivei/foundationkit/app"
+	"github.com/go-kit/kit/endpoint"
+)
+
+func New(c Config) endpoint.Middleware {
+	ch := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ch:
+				if !app.IsHealthy() {
+					app.SetHealthy()
+				}
+			case <-time.After(c.Timeout):
+				if app.IsHealthy() {
+					if c.Logger != nil {
+						c.Logger.Warn().
+							Dur("timeout", c.Timeout).
+							Msg("Endpoint didn't receive any request and it's stale")
+					}
+					app.SetUnhealthy()
+				}
+			}
+		}
+	}()
+
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, request interface{}) (interface{}, error) {
+			ch <- struct{}{}
+			return next(ctx, request)
+		}
+	}
+}

--- a/gokitmiddlewares/stalemiddleware/middleware.go
+++ b/gokitmiddlewares/stalemiddleware/middleware.go
@@ -8,32 +8,46 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
+// New returns a new stale middleware
+// This middleware marks the application as
+// unhealthy if no request is received in
+// the allotted time.
+//
+// Unhealthy is a final state for now, so the checker
+// stops after reaching unhealthy.
+//
+// With a better health handler we could try
+// to recover from it.
 func New(c Config) endpoint.Middleware {
-	ch := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-ch:
-				if !app.IsHealthy() {
-					app.SetHealthy()
-				}
-			case <-time.After(c.Timeout):
-				if app.IsHealthy() {
-					if c.Logger != nil {
-						c.Logger.Warn().
-							Dur("timeout", c.Timeout).
-							Msg("Endpoint didn't receive any request and it's stale")
-					}
-					app.SetUnhealthy()
-				}
-			}
-		}
-	}()
+	var lastKnownRequestTime int64
+
+	go backgroundStaleCheck(c, &lastKnownRequestTime)
 
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			ch <- struct{}{}
+			lastKnownRequestTime = time.Now().UnixNano()
 			return next(ctx, request)
 		}
 	}
+}
+
+func backgroundStaleCheck(c Config, lastKnownRequestTime *int64) {
+	time.Sleep(c.StartCheckAfter)
+	*lastKnownRequestTime = time.Now().UnixNano()
+	for {
+		time.Sleep(c.MaxTimeBetweenRequests)
+		if time.Since(time.Unix(0, *lastKnownRequestTime)) > c.MaxTimeBetweenRequests {
+			logAndSetUnhealthy(c)
+			return
+		}
+	}
+}
+
+func logAndSetUnhealthy(c Config) {
+	if c.Logger != nil {
+		c.Logger.Warn().
+			Dur("timeout", c.MaxTimeBetweenRequests).
+			Msg("Endpoint didn't receive any request and it's stale")
+	}
+	app.SetUnhealthy()
 }


### PR DESCRIPTION
This is a propose for an Endpoint middleware that marks the app as
unhealthy if no new request arrives until the defined timeout.

A new request would mark the app as healthy.

The idea is allow applications to be restarted by kubernetes if they
stop receiving requests. It's useful if your endpoint is executed by a
worker and the worker is frozen.