### PR TITLE
Adds logging middlewares

### DIFF
--- a/errors/code.go
+++ b/errors/code.go
@@ -1,11 +1,19 @@
 package errors
 
+import "github.com/rs/zerolog"
+
 // Code is the error code
 type Code string
 
 // String returns the code as a string
 func (c Code) String() string {
 	return string(c)
+}
+
+// MarshalZerologObject allows for zerolog to
+// log the error code as 'error_code': '...'
+func (c Code) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("error_code", string(c))
 }
 
 const (

--- a/errors/severity.go
+++ b/errors/severity.go
@@ -1,5 +1,7 @@
 package errors
 
+import "github.com/rs/zerolog"
+
 // Severity is the error severity. It's used to classify errors in groups to be easily handled by the code. For example,
 // a retry layer should be only checking for Runtime errors to retry. Or in an HTTP layer, errors of input type are always
 // returned a 400 status.
@@ -18,6 +20,12 @@ const (
 
 func (s Severity) String() string {
 	return string(s)
+}
+
+// MarshalZerologObject allows for zerolog to log the error
+// severity as 'error_severity': '...'
+func (s Severity) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("error_severity", string(s))
 }
 
 // GetSeverity returns the error severity. If there is not severity, SeverityUnset is returned.

--- a/gokitmiddlewares/loggingmiddleware/config.go
+++ b/gokitmiddlewares/loggingmiddleware/config.go
@@ -1,0 +1,73 @@
+package loggingmiddleware
+
+import (
+	"github.com/arquivei/foundationkit/errors"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// Config is a struct that configures the behavior of a
+// loggingmiddleware. All fields should be set unless marked
+// as optional.
+type Config struct {
+	// LogRequestIfLevel will log the request if this
+	// log level is enabled in the logger.
+	LogRequestIfLevel zerolog.Level
+
+	// TruncRequestAt will truncate the serialized request if
+	// the string length is above this value.
+	// Setting to zero disables truncating.
+	TruncRequestAt int
+
+	// LogResponseIfLevel will log the response if this
+	// log level is enabled in the logger.
+	LogResponseIfLevel zerolog.Level
+
+	// TruncResponseAt will truncate the serialized request if
+	// the string length is above this value.
+	// Setting to zero disables truncating.
+	TruncResponseAt int
+
+	// SuccessLevel is the log level of requests that are processed without error.
+	SuccessLevel zerolog.Level
+
+	// DefaultErrorLevel is the log level of requests that finished with some error.
+	// May be override by ErrorCodeMapLevel or SeverityMapLevel
+	DefaultErrorLevel zerolog.Level
+
+	// ErrorCodeMapLevel is used to override the error level using the error code.
+	// This is optional
+	ErrorCodeMapLevel map[errors.Code]zerolog.Level
+
+	// SeverityMapLevel is used to override the error level using the error severity.
+	// This is optional
+	SeverityMapLevel map[errors.Severity]zerolog.Level
+
+	// Logger is the default logger to be put in the context.
+	// If there is already a logger in the context, the context
+	// is not updated and the existing logger is used.
+	Logger *zerolog.Logger
+
+	// Meta are extra keys logged under 'endpoint_meta' key.
+	Meta Meta
+}
+
+// DefaultConfig contains sane defaults to configure a new logging middleware.
+var DefaultConfig = Config{
+	Logger: &log.Logger,
+
+	LogRequestIfLevel:  zerolog.DebugLevel,
+	TruncRequestAt:     200,
+	LogResponseIfLevel: zerolog.DebugLevel,
+	TruncResponseAt:    200,
+
+	SuccessLevel:      zerolog.InfoLevel,
+	DefaultErrorLevel: zerolog.ErrorLevel,
+
+	SeverityMapLevel: map[errors.Severity]zerolog.Level{
+		errors.SeverityInput:   zerolog.InfoLevel,
+		errors.SeverityRuntime: zerolog.WarnLevel,
+		errors.SeverityFatal:   zerolog.ErrorLevel,
+	},
+}

--- a/gokitmiddlewares/loggingmiddleware/context.go
+++ b/gokitmiddlewares/loggingmiddleware/context.go
@@ -1,0 +1,22 @@
+package loggingmiddleware
+
+import "context"
+
+type requestMetaKeyType int
+
+const requestMetaKey requestMetaKeyType = iota
+
+// GetRequestMeta returns a Meta added i nthe context by the
+// WithRequestMeta function
+func GetRequestMeta(ctx context.Context) Meta {
+	return ctx.Value(requestMetaKey).(Meta)
+}
+
+// WithRequestMeta returns a context the the given metadata.
+// This value is retrieved by the logging middleware and logged along
+// other information.
+// This is intended to be used by transport layers to send data to the
+// logging middleware on the endpoint layer.
+func WithRequestMeta(ctx context.Context, val Meta) context.Context {
+	return context.WithValue(ctx, requestMetaKey, val)
+}

--- a/gokitmiddlewares/loggingmiddleware/context.go
+++ b/gokitmiddlewares/loggingmiddleware/context.go
@@ -6,13 +6,13 @@ type requestMetaKeyType int
 
 const requestMetaKey requestMetaKeyType = iota
 
-// GetRequestMeta returns a Meta added i nthe context by the
+// GetRequestMeta returns a Meta added in the context by the
 // WithRequestMeta function
 func GetRequestMeta(ctx context.Context) Meta {
 	return ctx.Value(requestMetaKey).(Meta)
 }
 
-// WithRequestMeta returns a context the the given metadata.
+// WithRequestMeta returns a context the given metadata.
 // This value is retrieved by the logging middleware and logged along
 // other information.
 // This is intended to be used by transport layers to send data to the

--- a/gokitmiddlewares/loggingmiddleware/geterrorlevel.go
+++ b/gokitmiddlewares/loggingmiddleware/geterrorlevel.go
@@ -1,0 +1,39 @@
+package loggingmiddleware
+
+import (
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/rs/zerolog"
+)
+
+func getErrorLevel(c Config, err error) zerolog.Level {
+	lvl, ok := getLevelByErrorCode(c.ErrorCodeMapLevel, err)
+	if !ok {
+		lvl, ok = getLevelByErrorSeverity(c.SeverityMapLevel, err)
+		if !ok {
+			lvl = c.DefaultErrorLevel
+		}
+	}
+	return lvl
+}
+
+func getLevelByErrorCode(m map[errors.Code]zerolog.Level, err error) (zerolog.Level, bool) {
+	if len(m) == 0 {
+		return zerolog.DebugLevel, false
+	}
+	lvl, ok := m[errors.GetCode(err)]
+	if !ok {
+		return zerolog.DebugLevel, false
+	}
+	return lvl, ok
+}
+
+func getLevelByErrorSeverity(m map[errors.Severity]zerolog.Level, err error) (zerolog.Level, bool) {
+	if len(m) == 0 {
+		return zerolog.DebugLevel, false
+	}
+	lvl, ok := m[errors.GetSeverity(err)]
+	if !ok {
+		return zerolog.DebugLevel, false
+	}
+	return lvl, ok
+}

--- a/gokitmiddlewares/loggingmiddleware/geterrorlevel.go
+++ b/gokitmiddlewares/loggingmiddleware/geterrorlevel.go
@@ -6,34 +6,37 @@ import (
 )
 
 func getErrorLevel(c Config, err error) zerolog.Level {
-	lvl, ok := getLevelByErrorCode(c.ErrorCodeMapLevel, err)
-	if !ok {
-		lvl, ok = getLevelByErrorSeverity(c.SeverityMapLevel, err)
-		if !ok {
-			lvl = c.DefaultErrorLevel
-		}
+	if lvl, ok := getLevelByErrorCode(c.ErrorCodeMapLevel, err); ok {
+		return lvl
 	}
-	return lvl
+
+	if lvl, ok := getLevelByErrorSeverity(c.SeverityMapLevel, err); ok {
+		return lvl
+	}
+
+	return c.DefaultErrorLevel
 }
 
 func getLevelByErrorCode(m map[errors.Code]zerolog.Level, err error) (zerolog.Level, bool) {
 	if len(m) == 0 {
 		return zerolog.DebugLevel, false
 	}
-	lvl, ok := m[errors.GetCode(err)]
-	if !ok {
-		return zerolog.DebugLevel, false
+
+	if lvl, ok := m[errors.GetCode(err)]; ok {
+		return lvl, true
 	}
-	return lvl, ok
+
+	return zerolog.DebugLevel, false
 }
 
 func getLevelByErrorSeverity(m map[errors.Severity]zerolog.Level, err error) (zerolog.Level, bool) {
 	if len(m) == 0 {
 		return zerolog.DebugLevel, false
 	}
-	lvl, ok := m[errors.GetSeverity(err)]
-	if !ok {
-		return zerolog.DebugLevel, false
+
+	if lvl, ok := m[errors.GetSeverity(err)]; ok {
+		return lvl, true
 	}
-	return lvl, ok
+
+	return zerolog.DebugLevel, false
 }

--- a/gokitmiddlewares/loggingmiddleware/loggercontext.go
+++ b/gokitmiddlewares/loggingmiddleware/loggercontext.go
@@ -1,0 +1,61 @@
+package loggingmiddleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/arquivei/foundationkit/request"
+	"github.com/arquivei/foundationkit/trace"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func initLoggerContext(ctx context.Context, l zerolog.Logger) context.Context {
+	// Creates a copy, otherwise the logger is updated for every request
+	// Ensures that there is a logger in the context
+	// If there is a logger in the context, it's not updated
+	return l.WithContext(ctx)
+}
+
+func enrichLoggerContext(ctx context.Context, name string, c Config, req interface{}) {
+	l := log.Ctx(ctx)
+	l.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+		if c.Meta != nil {
+			zctx = zctx.Interface("endpoint_meta", c.Meta)
+		}
+
+		if l.WithLevel(c.LogRequestIfLevel).Enabled() {
+			zctx = zctx.Str("endpoint_request", toString(req, c.TruncRequestAt))
+		}
+
+		if meta := GetRequestMeta(ctx); len(meta) > 0 {
+			zctx = zctx.Interface("request_meta", meta)
+		}
+
+		if rid := request.GetRequestIDFromContext(ctx); !rid.IsEmpty() {
+			zctx = zctx.EmbedObject(request.GetRequestIDFromContext(ctx))
+		} else {
+			log.Warn().Msg("Request doesn't have a Request ID! Did you forget to use trackingmiddleware on the trasport layer?")
+		}
+
+		if t := trace.GetTraceFromContext(ctx); !trace.IDIsEmpty(t.ID) {
+			zctx = zctx.EmbedObject(trace.GetTraceFromContext(ctx))
+		} else {
+			log.Warn().Msg("Reqeust doesn't have a trace! Did you forget to use trackingmiddleware on the trasport layer?")
+		}
+
+		return zctx.Str("endpoint_name", name)
+
+	})
+}
+
+func enrichLoggerAfterResponse(ctx context.Context, c Config, begin time.Time, resp interface{}) {
+	l := log.Ctx(ctx)
+
+	l.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+		if l.WithLevel(c.LogResponseIfLevel).Enabled() {
+			zctx = zctx.Str("endpoint_response", toString(resp, c.TruncResponseAt))
+		}
+		return zctx.Dur("endpoint_took", time.Since(begin))
+	})
+}

--- a/gokitmiddlewares/loggingmiddleware/meta.go
+++ b/gokitmiddlewares/loggingmiddleware/meta.go
@@ -1,0 +1,4 @@
+package loggingmiddleware
+
+// Meta is a map containing arbitrary metadata to be passed to the logging middleware.
+type Meta map[string]string

--- a/gokitmiddlewares/loggingmiddleware/middleware.go
+++ b/gokitmiddlewares/loggingmiddleware/middleware.go
@@ -1,0 +1,67 @@
+package loggingmiddleware
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/go-kit/kit/endpoint"
+	"github.com/rs/zerolog/log"
+)
+
+// New returns a new go-kit logging middleware with the given name and configuration.
+// It will panic if the name is empty.
+func New(name string, c Config) endpoint.Middleware {
+	if name == "" {
+		panic("endpoint name is empty")
+	}
+
+	if c.Logger == nil {
+		panic("logger is nil")
+	}
+
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (resp interface{}, err error) {
+			begin := time.Now()
+
+			ctx = initLoggerContext(ctx, *c.Logger)
+
+			enrichLoggerContext(ctx, name, c, req)
+
+			defer func() {
+				doLogging(ctx, c, begin, resp, err)
+			}()
+
+			return next(ctx, req)
+		}
+	}
+}
+
+func doLogging(ctx context.Context, c Config, begin time.Time, resp interface{}, err error) {
+	enrichLoggerAfterResponse(ctx, c, begin, resp)
+
+	l := log.Ctx(ctx)
+
+	if err != nil {
+		e := l.WithLevel(getErrorLevel(c, err)).Err(err)
+		if code := errors.GetCode(err); code.String() != "" {
+			e = e.Str("error_code", code.String())
+		}
+		if s := errors.GetSeverity(err); s.String() != "" {
+			e = e.Str("error_severity", s.String())
+		}
+		e.Msg("Request failed")
+		return
+	}
+
+	l.WithLevel(c.SuccessLevel).Msg("Request successful")
+}
+
+func toString(i interface{}, n int) string {
+	s := fmt.Sprintf("%#v", i)
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/httpmiddlewares/enrichloggingmiddleware/middleware.go
+++ b/httpmiddlewares/enrichloggingmiddleware/middleware.go
@@ -1,0 +1,24 @@
+package enrichloggingmiddleware
+
+import (
+	"net/http"
+
+	"github.com/arquivei/foundationkit/gokitmiddlewares/loggingmiddleware"
+)
+
+func New(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		meta := loggingmiddleware.Meta{
+			"url":         r.URL.String(),
+			"user_agent":  r.UserAgent(),
+			"remote_addr": r.RemoteAddr,
+		}
+
+		ctx := r.Context()
+		ctx = loggingmiddleware.WithRequestMeta(ctx, meta)
+		r = r.WithContext(ctx)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/httpmiddlewares/trackingmiddleware/middleware.go
+++ b/httpmiddlewares/trackingmiddleware/middleware.go
@@ -1,0 +1,22 @@
+package trackingmiddleware
+
+import (
+	"net/http"
+
+	"github.com/arquivei/foundationkit/request"
+	"github.com/arquivei/foundationkit/trace"
+)
+
+func New(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = request.WithRequestID(ctx)
+		ctx = trace.WithTrace(ctx, trace.GetTraceFromHTTRequest(r))
+
+		w.Header().Set("X-REQUESTID", request.GetRequestIDFromContext(ctx).String())
+		trace.SetTraceInHTTPResponse(trace.GetTraceFromContext(ctx), w)
+
+		r = r.WithContext(ctx)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/trace/span.go
+++ b/trace/span.go
@@ -18,7 +18,7 @@ func (s *Span) End(err error) {
 	if s.span != nil {
 		s.span.End()
 		if err != nil {
-			s.span.AddAttributes(trace.StringAttribute("error_code", errors.GetErrorCode(err).String()))
+			s.span.AddAttributes(trace.StringAttribute("error_code", errors.GetCode(err).String()))
 		}
 	}
 }

--- a/trace/zerolog.go
+++ b/trace/zerolog.go
@@ -7,3 +7,10 @@ import "github.com/rs/zerolog"
 func (i ID) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("trace_id", i.String())
 }
+
+func (t Trace) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("trace_id", t.ID.String())
+	if t.ProbabilitySample != nil {
+		e.Float64("trace_probability_sample", *t.ProbabilitySample)
+	}
+}


### PR DESCRIPTION
Added an endpoint logging middleware to be used with go-kit. The
middleware is configurable provided with a default config struct.

There is also two http middlewares to be used with gorilla/mux that
are supposed to be used with the logging middleware. One adds tracking
information (RequestID and Trace information) and the other adds extra
HTTP information in the context for the logging middleware to log.