### PR TITLE
Fix logger racing condition

### DIFF
--- a/gokitmiddlewares/loggingmiddleware/loggercontext.go
+++ b/gokitmiddlewares/loggingmiddleware/loggercontext.go
@@ -10,12 +10,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func initLoggerContext(ctx context.Context, l zerolog.Logger) context.Context {
+func initLoggerContext(ctx context.Context, l zerolog.Logger) (*zerolog.Logger, context.Context) {
 	// Creates a copy, otherwise the logger is updated for every request
 	// Ensures that there is a logger in the context
 	// If the same logger is in the context already or if there is a disabled
 	// logger already in the context, the context is not updated.
-	return l.WithContext(ctx)
+	logger := l.With().Logger()
+	return &logger, logger.WithContext(ctx)
 }
 
 func enrichLoggerContext(ctx context.Context, l *zerolog.Logger, name string, c Config, req interface{}) {

--- a/gokitmiddlewares/loggingmiddleware/middleware.go
+++ b/gokitmiddlewares/loggingmiddleware/middleware.go
@@ -8,7 +8,6 @@ import (
 	"github.com/arquivei/foundationkit/errors"
 	"github.com/go-kit/kit/endpoint"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // MustNew calls New and panics in case of error.
@@ -35,8 +34,7 @@ func New(name string, c Config) (endpoint.Middleware, error) {
 		return func(ctx context.Context, req interface{}) (resp interface{}, err error) {
 			begin := time.Now()
 
-			ctx = initLoggerContext(ctx, *c.Logger)
-			l := log.Ctx(ctx)
+			l, ctx := initLoggerContext(ctx, *c.Logger)
 
 			enrichLoggerContext(ctx, l, name, c, req)
 			defer func() {


### PR DESCRIPTION
The logger was not being correctly copied inside the logging
middleware and race conditions were happening under certain loads.

The init functions was changed to use the With functions that copies the
logger properly.