### PR TITLE
Adds httpcomm package with CommunicateWithJSON function

### DIFF
--- a/httpcomm/communicatewithjson.go
+++ b/httpcomm/communicatewithjson.go
@@ -1,0 +1,137 @@
+package httpcomm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/trace"
+)
+
+// CommunicateWithJSON uses a given @httpClient to communicate with a HTTP
+// server at @fullURL using the specified @httpMethod. This function will
+// send @requestData marshalled as a JSON content and wait for the server
+// response. The response will be written into the given @outResponse (it
+// will mutate the parameter contents) using the json unmarshaling rules set
+// by @outResponse itself.
+//
+// To reduce damage in case of bugs or attacks, a @maxAcceptedBodySize must be
+// passed, and bodies contents larger than this will be considered noxious and
+// return an error.
+//
+// A value of @maxErrBodySize must be passed to indicate how much of response
+// contents can be added into the error message.
+func CommunicateWithJSON(
+	ctx context.Context,
+	httpClient http.Client,
+	httpMethod HTTPMethod,
+	fullURL string,
+	requestData interface{},
+	maxAcceptedBodySize int64,
+	maxErrBodySize int,
+
+	// output response, on success, will be overwritten. This is not
+	// a nice design, but it allows the ErrCodeDecodeError well unmarshalling
+	// json to stay inside this function, and avoids the need of a cast by the caller.
+	outResponse interface{},
+) (trace.Trace, error) {
+	const op = errors.Op("httpcomm.CommunicateWithJSON")
+
+	if ctx.Err() != nil {
+		return trace.Trace{}, errors.E(
+			op,
+			ErrCodeExpiredContext,
+			errors.SeverityRuntime,
+			"refusing request due to expired context",
+			errors.KV("CONTEXT_ERROR", ctx.Err().Error()),
+		)
+	}
+
+	requestDataBody, err := json.Marshal(requestData)
+	if err != nil {
+		return trace.Trace{}, errors.E(op, ErrCodeRequestError, errors.SeverityFatal, err)
+	}
+
+	httpRequest, err := http.NewRequestWithContext(ctx, httpMethod, fullURL, bytes.NewReader(requestDataBody))
+	if err != nil {
+		return trace.Trace{}, errors.E(op, ErrCodeRequestError, errors.SeverityFatal, err)
+	}
+
+	if trace.IDIsEmpty(trace.GetIDFromContext(ctx)) {
+		// Force a random trace into request if no trace in context.
+		// FIXME : trace.GetIDFromContext(ctx) results in a warning if there's no context in the trace. Implement
+		//         a trace.ExistsInContext(ctx) to allow checking.
+		ctx = trace.WithTrace(ctx, trace.Trace{})
+	}
+	trace.SetTraceInHTTPRequest(ctx, httpRequest)
+
+	httpResponse, err := httpClient.Do(httpRequest)
+	if err != nil {
+		if isHTTPTimeoutError(err) {
+			return trace.Trace{}, errors.E(op, ErrCodeTimeout, errors.SeverityRuntime, err)
+		}
+
+		return trace.Trace{}, errors.E(
+			op,
+			ErrCodeRequestError,
+			errors.SeverityRuntime,
+			err,
+		)
+	}
+
+	defer httpResponse.Body.Close()
+	responseTrace := trace.GetTraceFromHTTPResponse(httpResponse)
+
+	limitedReader := io.LimitReader(httpResponse.Body, maxAcceptedBodySize+1)
+	contents, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return trace.Trace{}, errors.E(
+			op,
+			ErrCodeDecodeError,
+			errors.SeverityRuntime,
+			err,
+		)
+	}
+
+	if int64(len(contents)) > maxAcceptedBodySize {
+		return responseTrace, errors.E(
+			op,
+			ErrCodeResponseTooLong,
+			errors.SeverityRuntime,
+			errors.Errorf("received contents longer than the allowed %d bytes", maxAcceptedBodySize),
+		)
+	}
+
+	if err := json.Unmarshal(contents, outResponse); err != nil {
+		contentsStr := string(contents)
+		if len(contentsStr) > maxErrBodySize {
+			contentsStr = string(contents[0:maxErrBodySize-5]) + "(...)"
+		}
+
+		return responseTrace, errors.E(
+			op,
+			ErrCodeDecodeError,
+			errors.SeverityRuntime,
+			fmt.Errorf("failed to decode received response: %v", err),
+			errors.KV("HTTP", httpResponse.StatusCode),
+			errors.KV("BODY", contentsStr),
+		)
+	}
+
+	return responseTrace, nil
+}
+
+func isHTTPTimeoutError(httpError error) bool {
+	err, ok := httpError.(*url.Error)
+	if !ok {
+		return false
+	}
+
+	return err.Timeout()
+}

--- a/httpcomm/communicatewithjson_test.go
+++ b/httpcomm/communicatewithjson_test.go
@@ -1,0 +1,238 @@
+package httpcomm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/trace"
+	"github.com/rs/zerolog"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommunicateWithJSON_Success(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	type RequestType struct {
+		Integer int
+	}
+
+	type ResponseType struct {
+		Integer int
+		String  string
+	}
+
+	ctx := context.Background()
+	ctx = trace.WithNewTrace(ctx)
+	requestTrace := trace.GetTraceFromContext(ctx)
+
+	testServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			receivedTrace := trace.GetTraceFromHTTPRequest(r)
+
+			// Casting traces to String so assertion message is friedlier to human eyes
+			assert.Equal(t, requestTrace.ID.String(), receivedTrace.ID.String(), "server trace id")
+			assert.Equal(t, requestTrace.ProbabilitySample, receivedTrace.ProbabilitySample, "server trace probability sample")
+
+			trace.SetTraceInHTTPResponse(receivedTrace, w)
+			// NOTE : theres no implementation to send request id over http response yet
+			w.WriteHeader(http.StatusAccepted) // Should always be the last header
+
+			var request RequestType
+			err := json.NewDecoder(r.Body).Decode(&request)
+			if err != nil {
+				assert.FailNow(t, "Server received bad request", "Error: %v", err)
+			}
+
+			if request.Integer != 123 {
+				assert.FailNow(t, "Server received request integer does not match", "Integer: expected %d, received %d", 123, request.Integer)
+			}
+
+			response := ResponseType{
+				Integer: 456,
+				String:  "Not stringer",
+			}
+
+			err = json.NewEncoder(w).Encode(response)
+			if err != nil {
+				assert.FailNow(t, "Server should not fail to encode response", "Error: %v", err)
+			}
+		},
+	))
+
+	var response ResponseType
+
+	responseTrace, err := CommunicateWithJSON(
+		ctx,
+		http.Client{},
+		http.MethodPost,
+		testServer.URL,
+		RequestType{Integer: 123},
+		100,
+		20,
+		/*out*/ &response,
+	)
+
+	if !assert.NoError(t, err, "Should not return error") {
+		return
+	}
+
+	assert.Equal(t, 456, response.Integer, "Response integer")
+	assert.Equal(t, "Not stringer", response.String)
+
+	// Casting traces to String so assertion message is friedlier to human eyes
+	assert.Equal(t, requestTrace.ID.String(), responseTrace.ID.String(), "trace id")
+	assert.Equal(t, requestTrace.ProbabilitySample, responseTrace.ProbabilitySample, "probability sample")
+}
+
+func TestCommunicateWithJSON_CommunicationErrors(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	type RequestType struct {
+		Integer int
+	}
+
+	type ResponseType struct {
+		Integer int
+		String  string
+	}
+
+	tests := []struct {
+		name                   string
+		requestInteger         int
+		serverResponseStatus   int
+		serverResponseContents string
+		expectedCode           errors.Code
+		expectedSeverity       errors.Severity
+		expectedMessage        string
+	}{
+		{
+			name:                   "Unexpected HTML response",
+			requestInteger:         1,
+			serverResponseStatus:   http.StatusForbidden,
+			serverResponseContents: `<html><head><title>403</title></head><body>Ah ah ah, you didn't say the magic word!</body></html>`,
+			expectedCode:           ErrCodeDecodeError,
+			expectedSeverity:       errors.SeverityRuntime,
+			expectedMessage:        "failed to decode received response: invalid character '<' looking for beginning of value [HTTP=403,BODY=<html><head><ti(...)]",
+		},
+		{
+			name:                   "Unexpected HTML response",
+			requestInteger:         1,
+			serverResponseStatus:   http.StatusForbidden,
+			serverResponseContents: `<html><head><title>Bacon ipsum</title></head><body>Bacon ipsum dolor amet venison andouille buffalo short ribs tenderloin ground round</body></html>`,
+			expectedCode:           ErrCodeResponseTooLong,
+			expectedSeverity:       errors.SeverityRuntime,
+			expectedMessage:        "received contents longer than the allowed 100 bytes",
+		},
+	}
+
+	for _, tc := range tests {
+		testCase := tc
+
+		t.Run(testCase.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			testServer := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					var request RequestType
+					err := json.NewDecoder(r.Body).Decode(&request)
+					if err != nil {
+						assert.FailNow(tt, "Received bad request", "Error: %v", err)
+					}
+
+					if request.Integer != testCase.requestInteger {
+						assert.FailNow(tt, "Received request integer does not match", "Integer: expected %d, received %d", testCase.requestInteger, request.Integer)
+					}
+
+					w.WriteHeader(tc.serverResponseStatus)
+					fmt.Fprintln(w, testCase.serverResponseContents)
+				},
+			))
+
+			var response ResponseType
+
+			_, err := CommunicateWithJSON(
+				context.Background(),
+				http.Client{},
+				http.MethodPost,
+				testServer.URL,
+				RequestType{Integer: testCase.requestInteger},
+				100,
+				20,
+				/*out*/ response,
+			)
+
+			assert.Error(tt, err, "Error expected")
+			assert.Equal(tt, testCase.expectedCode, errors.GetCode(err), "Error code")
+			assert.Equal(tt, testCase.expectedSeverity, errors.GetSeverity(err), "Error severity")
+			assert.EqualError(tt, errors.GetRootErrorWithKV(err), testCase.expectedMessage, "Error message")
+		})
+	}
+}
+
+func TestCommunicateWithJSON_Timeout(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	testServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(10 * time.Second)
+		},
+	))
+
+	var request struct{}
+	var response struct{}
+
+	_, err := CommunicateWithJSON(
+		context.Background(),
+		http.Client{Timeout: 1},
+		http.MethodPost,
+		testServer.URL,
+		request,
+		2*(1<<10), // 2KB
+		20,
+		/*out*/ response,
+	)
+
+	assert.Error(t, err, "Error expected")
+	assert.Equal(t, ErrCodeTimeout, errors.GetCode(err), "Error code")
+	assert.Equal(t, errors.SeverityRuntime, errors.GetSeverity(err), "Error severity")
+	// Not checking message as it changes on every test
+}
+
+func TestDoJSONRequest_ExpiredContext(t *testing.T) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+
+	testServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(10 * time.Second)
+		},
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var request struct{}
+	var response struct{}
+
+	_, err := CommunicateWithJSON(
+		ctx,
+		http.Client{Timeout: 1},
+		http.MethodPost,
+		testServer.URL,
+		request,
+		2*(1<<10), // 2KB
+		20,
+		/*out*/ response,
+	)
+
+	assert.Error(t, err, "Error expected")
+	assert.Equal(t, ErrCodeExpiredContext, errors.GetCode(err), "Error code")
+	assert.Equal(t, errors.SeverityRuntime, errors.GetSeverity(err), "Error severity")
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "refusing request due to expired context [CONTEXT_ERROR=context canceled]", "Error message")
+}

--- a/httpcomm/entity_httpmethod.go
+++ b/httpcomm/entity_httpmethod.go
@@ -1,0 +1,5 @@
+package httpcomm
+
+// HTTPMethod is the method to use over HTTP. Expects the same values
+// as defined per Go's http package.
+type HTTPMethod = string

--- a/httpcomm/errors.go
+++ b/httpcomm/errors.go
@@ -1,0 +1,32 @@
+package httpcomm
+
+import "github.com/arquivei/foundationkit/errors"
+
+const (
+	// ErrCodeExpiredContext is returned when an operation won't be
+	// executed due to it's context being expired before the operation
+	// start.
+	ErrCodeExpiredContext errors.Code = "EXPIRED_CONTEXT"
+
+	// ErrCodeRequestError is returned when a request could not be generated
+	// for some reason or other.
+	ErrCodeRequestError errors.Code = "REQUEST_ERROR"
+
+	// ErrCodeDecodeError is returned when a received response body could not be
+	// decoded. This usually means transport layer errors, such as HTTP or DNS.
+	ErrCodeDecodeError errors.Code = "DECODE_ERROR"
+
+	// ErrCodeResponseTooLong is returned when a received response body is too
+	// long and can be assumed as an serious malfunction or an attack.
+	ErrCodeResponseTooLong errors.Code = "RESPONSE_TOO_LONG"
+
+	// ErrCodeTimeout is returned when a client side timeout on the HTTP Client
+	// is detected. Note that as there are various ways of a timeout occurring, this
+	// error code might not be returned in every type of timeout error happening.
+	ErrCodeTimeout errors.Code = "TIMEOUT"
+
+	// ErrCodeMissing is returned when a received response has an error without
+	// code. This should never happen, indicating unexpected behavior in the
+	// HTTP Server.
+	ErrCodeMissing errors.Code = "CODE_MISSING"
+)

--- a/httpmiddlewares/trackingmiddleware/middleware.go
+++ b/httpmiddlewares/trackingmiddleware/middleware.go
@@ -7,11 +7,12 @@ import (
 	"github.com/arquivei/foundationkit/trace"
 )
 
+// New instantiates a new tracking middleware wrapping the @next handler.
 func New(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		ctx = request.WithNewRequestID(ctx)
-		ctx = trace.WithTrace(ctx, trace.GetTraceFromHTTRequest(r))
+		ctx = trace.WithTrace(ctx, trace.GetTraceFromHTTPRequest(r))
 
 		w.Header().Set("X-REQUESTID", request.GetRequestIDFromContext(ctx).String())
 		trace.SetTraceInHTTPResponse(trace.GetTraceFromContext(ctx), w)

--- a/trace/http.go
+++ b/trace/http.go
@@ -14,9 +14,9 @@ const (
 	headerProbabilitySample = "X-PROBABILITYSAMPLE"
 )
 
-// GetTraceFromHTTRequest returns a Trace using the trace
+// GetTraceFromHTTPRequest returns a Trace using the trace
 // ID and the probability sample get from the header of @r
-func GetTraceFromHTTRequest(r *http.Request) Trace {
+func GetTraceFromHTTPRequest(r *http.Request) Trace {
 	idStr := r.Header.Get(headerTraceID)
 	id := decode([]byte(idStr))
 
@@ -47,6 +47,26 @@ func SetTraceInHTTPRequest(ctx context.Context, request *http.Request) {
 	trace := GetTraceFromContext(ctx)
 	request.Header.Set(headerTraceID, trace.ID.String())
 	request.Header.Set(headerProbabilitySample, fmt.Sprintf("%f", *trace.ProbabilitySample))
+}
+
+// GetTraceFromHTTPResponse returns a Trace using the trace
+// ID and the probability sample get from the header of @r
+func GetTraceFromHTTPResponse(r *http.Response) Trace {
+	idStr := r.Header.Get(headerTraceID)
+	id := decode([]byte(idStr))
+
+	probabilitySampleStr := r.Header.Get(headerProbabilitySample)
+	probabilitySample, err := strconv.ParseFloat(probabilitySampleStr, 64)
+
+	var probabilitySamplePtr *float64
+	if err == nil {
+		probabilitySamplePtr = &probabilitySample
+	}
+
+	return Trace{
+		ID:                id,
+		ProbabilitySample: probabilitySamplePtr,
+	}
 }
 
 // SetTraceInHTTPResponse sets the header of @response using @trace.

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,64 +10,80 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetTraceFromHTTRequest(t *testing.T) {
+func TestGetTraceFromHTTPRequest(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := GetTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTRequest_ErrorParseProbabilitySample(t *testing.T) {
+func TestGetTraceFromHTTPRequest_ErrorParseProbabilitySample(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5a")
 
-	trace := GetTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTRequest_WithoutHeader(t *testing.T) {
+func TestGetTraceFromHTTPRequest_WithoutHeader(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
-	trace := GetTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTPRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTRequest_WithoutProbabilitySample(t *testing.T) {
+func TestGetTraceFromHTTPRequest_WithoutProbabilitySample(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 
-	trace := GetTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTRequest_WithoutTraceID(t *testing.T) {
+func TestGetTraceFromHTTPRequest_WithoutTraceID(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := GetTraceFromHTTRequest(r)
+	trace := GetTraceFromHTTPRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
+}
+
+func TestGetTraceFromHTTPResponse(t *testing.T) {
+	ps := 0.75
+	trace := Trace{
+		ID:                decode([]byte("000000000000000000000000bebacafe")),
+		ProbabilitySample: &ps,
+	}
+
+	response := http.Response{}
+	response.Header = make(http.Header)
+	response.Header.Set(headerTraceID, trace.ID.String())
+	response.Header.Set(headerProbabilitySample, fmt.Sprintf("%f", *trace.ProbabilitySample))
+
+	assert.Equal(t, "000000000000000000000000bebacafe", response.Header.Get(headerTraceID))
+	assert.Equal(t, "0.750000", fmt.Sprintf("%f", *trace.ProbabilitySample))
 }
 
 func TestSetTraceInHTTPResponse(t *testing.T) {


### PR DESCRIPTION
The httpcomm.CommunicateWithJSON handles the boring, repeated logic
of marshaling a struct into a json request, sending over HTTP, receving
a response marshalled back to another struct. The function also does
some basic safety checking such as limiting the size of error messages
or having a maximum accepted response body size.

Trace ID is fetched from the passed context, and the Response Trace ID
is returned for double checking or in case the service might return
a new trace ID. Theres no formal solution for communicating with HTTP
Servers that does not work with trace yet.