### PR TITLE
Adds HTTP Methods to Request ID

### DIFF
--- a/httpmiddlewares/trackingmiddleware/middleware.go
+++ b/httpmiddlewares/trackingmiddleware/middleware.go
@@ -14,7 +14,7 @@ func New(next http.Handler) http.Handler {
 		ctx = request.WithNewRequestID(ctx)
 		ctx = trace.WithTrace(ctx, trace.GetTraceFromHTTPRequest(r))
 
-		w.Header().Set("X-REQUESTID", request.GetRequestIDFromContext(ctx).String())
+		request.SetInHTTPResponse(request.GetRequestIDFromContext(ctx), w)
 		trace.SetTraceInHTTPResponse(trace.GetTraceFromContext(ctx), w)
 
 		r = r.WithContext(ctx)

--- a/request/http.go
+++ b/request/http.go
@@ -1,0 +1,70 @@
+package request
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	// HTTPHeaderID is the HTTP Header to be used when sending ID in
+	// HTTP Requests or Responses
+	HTTPHeaderID = "X-REQUESTID"
+)
+
+// GetFromHTTPRequest attempts to read a Request ID from the given @r http request's
+// header. If no ID is found, or the found ID is ill-formatted, an empty ID is returned.
+func GetFromHTTPRequest(r *http.Request) ID {
+	idStr := r.Header.Get(HTTPHeaderID)
+
+	id, err := Parse(idStr)
+	if err != nil {
+		return ID{}
+	}
+
+	return id
+}
+
+// SetInHTTPRequest will add the ID registered in @ctx into the given
+// @request as a HTTP Header. If @request is nil, an warning log will
+// be emitted and nothing will be changed.
+func SetInHTTPRequest(ctx context.Context, request *http.Request) {
+	if request == nil {
+		log.Warn().
+			Str("method", "request.SetInHTTPRequest").
+			Msg("[FoundationKit] Request is nil. Nothing will happen")
+		return
+	}
+
+	id := GetRequestIDFromContext(ctx)
+	request.Header.Set(HTTPHeaderID, id.String())
+}
+
+// GetFromHTTPResponse attempts to read a Request ID from the given @r http response's
+// header. If no ID is found, or the found ID is ill-formatted, an empty ID is returned.
+func GetFromHTTPResponse(r *http.Response) ID {
+	idStr := r.Header.Get(HTTPHeaderID)
+
+	id, err := Parse(idStr)
+	if err != nil {
+		return ID{}
+	}
+
+	return id
+}
+
+// SetInHTTPResponse will add the ID registered in @ctx into the given
+// @request as a HTTP Header. If @request is nil, an warning log will
+// be emitted and nothing will be changed.
+//
+// nolint: interfacer
+func SetInHTTPResponse(id ID, response http.ResponseWriter) {
+	if response == nil {
+		log.Warn().
+			Str("method", "request.SetInHTTPResponse").
+			Msg("[FoundationKit] Response is nil. Nothing will happen")
+	}
+
+	response.Header().Set(HTTPHeaderID, id.String())
+}

--- a/request/http_test.go
+++ b/request/http_test.go
@@ -1,0 +1,71 @@
+package request
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFromHTTPRequest(t *testing.T) {
+	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
+	assert.NoError(t, err)
+
+	r.Header.Add(HTTPHeaderID, "1598556827687-01EGRPJW17DMNTVAK3C6F5WQMW")
+	assert.Equal(t, "1598556827687-01EGRPJW17DMNTVAK3C6F5WQMW", GetFromHTTPRequest(r).String())
+}
+
+func TestGetFromHTTPRequest_WithoutHeader(t *testing.T) {
+	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
+	assert.NoError(t, err)
+
+	assert.True(t, IsEmpty(GetFromHTTPRequest(r)))
+}
+
+func TestSetInHTTPRequest(t *testing.T) {
+	id := newID()
+
+	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
+	assert.NoError(t, err)
+
+	SetInHTTPRequest(WithRequestID(context.Background(), id), r)
+
+	assert.Equal(t, id.String(), r.Header.Get(HTTPHeaderID))
+}
+
+func TestSetInHTTPRequest_EmptyID(t *testing.T) {
+	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
+	assert.NoError(t, err)
+
+	SetInHTTPRequest(WithRequestID(context.Background(), ID{}), r)
+
+	assert.Empty(t, r.Header.Get(HTTPHeaderID))
+}
+
+func TestGetFromHTTPResponse(t *testing.T) {
+	id := newID()
+
+	response := http.Response{}
+	response.Header = make(http.Header)
+	response.Header.Set(HTTPHeaderID, id.String())
+
+	assert.Equal(t, id.String(), GetFromHTTPResponse(&response).String())
+}
+
+func TestSetInHTTPResponse(t *testing.T) {
+	id := newID()
+
+	r := httptest.NewRecorder()
+	SetInHTTPResponse(id, r)
+
+	assert.Equal(t, id.String(), r.Header().Get(HTTPHeaderID))
+}
+
+func TestSetInHTTPResponse_EmptyID(t *testing.T) {
+	r := httptest.NewRecorder()
+	SetInHTTPResponse(ID{}, r)
+
+	assert.Empty(t, r.Header().Get(HTTPHeaderID))
+}

--- a/request/id.go
+++ b/request/id.go
@@ -35,25 +35,43 @@ func (i ID) IsEmpty() bool {
 // UnmarshalJSON parses an ID from a json
 func (i *ID) UnmarshalJSON(b []byte) error {
 	b = bytes.Trim(b, `"`)
-	slices := strings.Split(string(b), ("-"))
 
-	if len(slices) != 2 {
-		return errors.New("wrong format for request id")
-	}
-
-	timestamp, err := strconv.Atoi(slices[0])
+	id, err := Parse(string(b))
 	if err != nil {
 		return err
 	}
 
-	i.timestamp = uint64(timestamp)
-	i.randomID = slices[1]
+	*i = id
 	return nil
 }
 
 // MarshalJSON converts ID to a string.
 func (i ID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
+}
+
+// Parse read the given @id into an request ID.
+func Parse(id string) (ID, error) {
+	slices := strings.Split(id, ("-"))
+
+	if len(slices) != 2 {
+		return ID{}, errors.New("wrong format for request id")
+	}
+
+	timestamp, err := strconv.Atoi(slices[0])
+	if err != nil {
+		return ID{}, err
+	}
+
+	return ID{
+		timestamp: uint64(timestamp),
+		randomID:  slices[1],
+	}, nil
+}
+
+// IsEmpty returns true if an request ID is in it's zero-value format
+func IsEmpty(id ID) bool {
+	return (id == ID{})
 }
 
 func newID() ID {


### PR DESCRIPTION
In the near future I'll do a pull request changing trace package methods to use the same shorter version names as being used in this changeset, and deprecating the longer ones.

***

The following functions were added to the request package:

 - request.GetFromHTTPRequest

 - request.SetInHTTPRequest

 - request.GetFromHTTPResponset

 - request.SetInHTTPResponse