### PR TITLE
[httpcomm] Add CommunicateWithJSONDetailed function

### DIFF
--- a/httpcomm/entity_responsedetails.go
+++ b/httpcomm/entity_responsedetails.go
@@ -1,0 +1,17 @@
+package httpcomm
+
+import (
+	"net/http"
+
+	"github.com/arquivei/foundationkit/request"
+	"github.com/arquivei/foundationkit/trace"
+)
+
+// ResponseDetails holds details of the received response, such as HTTP Status
+// and headers, if available.
+type ResponseDetails struct {
+	Trace      trace.Trace
+	RequestID  request.ID
+	StatusCode int
+	Header     http.Header
+}


### PR DESCRIPTION
The CommunicateWithJSONDetailed function has been added to the
httpcomm package. This new function returns details of the HTTP
Response, such as Status Code and HTTP Headers.

Since HTTP Headers implementation is unlikely to change, the Headers
from the official http package is returned. This reduces the need of
writing new code, but has some risk of breaking in the future.

The CommunicateWithJSON was not previously returning Request ID. The
Resquest ID has been added to the CommunicateWithJSONDetailed implementation.
The CommunicateWithJSON signature was, for now, left unchanged.