### PR TITLE
Adds feature that allows trace.WithLabels append to old labels

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -43,7 +43,16 @@ func GetTraceFromContext(ctx context.Context) Trace {
 }
 
 // WithLabels returns the @parent context with the labels @labels
+// If there are already labels in the context, the new labels will be merged
+// into the existing one. If a label with the same key already exists, it will
+// be overwritten
 func WithLabels(parent context.Context, labels map[string]string) context.Context {
+	if currentLabels := getLabelsFromContext(parent); currentLabels != nil {
+		for k, v := range labels {
+			currentLabels[k] = v
+		}
+		return parent
+	}
 	return context.WithValue(parent, contextKeyLabels, labels)
 }
 

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -88,6 +88,16 @@ func TestLabelsOperations(t *testing.T) {
 	labels := getLabelsFromContext(ctx)
 	assert.Equal(t, "v1", labels["k1"])
 	assert.Equal(t, "v2", labels["k2"])
+
+	ctx = WithLabels(ctx, map[string]string{
+		"k2": "v22",
+		"k3": "v3",
+	})
+
+	labels = getLabelsFromContext(ctx)
+	assert.Equal(t, "v1", labels["k1"])
+	assert.Equal(t, "v22", labels["k2"])
+	assert.Equal(t, "v3", labels["k3"])
 }
 
 // [DEPRECATED] Testing a Deprecated Methods


### PR DESCRIPTION
This feature is useful to add labels from multiple points in the code, without
overwriting the current labels.