### PR TITLE
[gokitmiddlewares] Added timeout middleware

### DIFF
--- a/gokitmiddlewares/timeoutmiddleware/config.go
+++ b/gokitmiddlewares/timeoutmiddleware/config.go
@@ -10,13 +10,18 @@ import (
 type Config struct {
 	// Timeout is the duration of the timeout
 	Timeout time.Duration
+
 	// Wait indicates if the middleware should wait for
 	// the next middleware to finish or it should return an error
 	// right away.
 	Wait bool
+
 	// ErrorSeverity is the severity of the error when the context
-	// is canceled, probably due the timeout
+	// is canceled, probably due the timeout.
 	ErrorSeverity errors.Severity
+
+	// ErrorCode is the error code when the context is canceled.
+	ErrorCode errors.Code
 }
 
 func NewDefaultConfig() Config {
@@ -24,5 +29,6 @@ func NewDefaultConfig() Config {
 		Timeout:       30 * time.Second,
 		Wait:          false,
 		ErrorSeverity: errors.SeverityRuntime,
+		ErrorCode:     errors.CodeEmpty,
 	}
 }

--- a/gokitmiddlewares/timeoutmiddleware/config.go
+++ b/gokitmiddlewares/timeoutmiddleware/config.go
@@ -1,0 +1,28 @@
+package timeoutmiddleware
+
+import (
+	"time"
+
+	"github.com/arquivei/foundationkit/errors"
+)
+
+// Config is the configuration of the timeout middleware.
+type Config struct {
+	// Timeout is the duration of the timeout
+	Timeout time.Duration
+	// Wait indicates if the middleware should wait for
+	// the next middleware to finish or it should return an error
+	// right away.
+	Wait bool
+	// ErrorSeverity is the severity of the error when the context
+	// is canceled, probably due the timeout
+	ErrorSeverity errors.Severity
+}
+
+func NewDefaultConfig() Config {
+	return Config{
+		Timeout:       30 * time.Second,
+		Wait:          false,
+		ErrorSeverity: errors.SeverityRuntime,
+	}
+}

--- a/gokitmiddlewares/timeoutmiddleware/middleware.go
+++ b/gokitmiddlewares/timeoutmiddleware/middleware.go
@@ -1,0 +1,65 @@
+package timeoutmiddleware
+
+import (
+	"context"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/go-kit/kit/endpoint"
+)
+
+// New returns a new timeout middleware.
+//
+// After timeout is reached, if the middleware is configured to wait,
+// it will just cancel the context and wait for next endpoint to return.
+// But if the middleware is configured to not wait, it will run the next endpoint
+// inside a go-routine and return error as soon as the context is canceled.
+func New(c Config) (endpoint.Middleware, error) {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		// Timeout is disabled
+		if c.Timeout <= 0 {
+			return next
+		}
+
+		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+			ctx, cancel := context.WithTimeout(ctx, c.Timeout)
+			defer cancel()
+
+			defer func() {
+				if err != nil && ctx.Err() != nil {
+					err = errors.E(err, c.ErrorSeverity)
+				}
+			}()
+
+			if c.Wait {
+				return next(ctx, request)
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case r := <-runAsync(ctx, next, request):
+
+				return r.response, r.err
+			}
+		}
+	}, nil
+}
+
+type asyncResult struct {
+	response interface{}
+	err      error
+}
+
+// runAsync executes next inside a go-routine and returns the result in a channel.
+func runAsync(ctx context.Context, next endpoint.Endpoint, request interface{}) <-chan asyncResult {
+	c := make(chan asyncResult)
+	go func() {
+		defer close(c)
+		response, err := next(ctx, request)
+		c <- asyncResult{
+			response: response,
+			err:      err,
+		}
+	}()
+	return c
+}


### PR DESCRIPTION
Adds a timeout middleware for a gokit's endpoint.

By default, the middleware will not await the next endpoint to finish in
case of the context ending, but this can be changed in the config.