### PR TITLE
Add a new Check function for access key validation

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: golangci/golangci-lint-action@v1
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.31
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/errors/severity.go
+++ b/errors/severity.go
@@ -8,7 +8,7 @@ import "github.com/rs/zerolog"
 type Severity string
 
 const (
-	//SeverityUnset indicates the severity was not set
+	// SeverityUnset indicates the severity was not set
 	SeverityUnset = Severity("")
 	// SeverityRuntime indicates the error is returned for an operation that should/could be executed again. For example, timeouts.
 	SeverityRuntime = Severity("runtime")

--- a/sefaz/accesskey/accesskey.go
+++ b/sefaz/accesskey/accesskey.go
@@ -4,13 +4,16 @@ package accesskey
 type AccessKey string
 
 // Validator is the interface that performs AccessKey validation
+// Deprecated: prefer using the Check function
 type Validator interface {
+	// Deprecated: prefer using the Check function
 	Check(AccessKey) error
 }
 
 type validator struct{}
 
 // NewValidator returns a real validator
+// Deprecated: prefer using the Check function instead of instantiating a Validator
 func NewValidator() Validator {
 	return &validator{}
 }

--- a/sefaz/accesskey/errors.go
+++ b/sefaz/accesskey/errors.go
@@ -6,13 +6,30 @@ import (
 
 var (
 	// ErrCodeInvalidAccessKey is an error code used to imply that an access key provided was not valid
+	// Deprecated: prefer using the more specific error codes and the Check function
 	ErrCodeInvalidAccessKey = errors.Code("INVALID_ACCESS_KEY")
 	// ErrCodeEmptyAccessKey is an error code used to imply that an access key provided was empty
 	ErrCodeEmptyAccessKey = errors.Code("EMPTY_ACCESS_KEY")
+	// ErrCodeInvalidLength is an error code used to imply that an access key does not contains 44 digits
+	ErrCodeInvalidLength = errors.Code("INVALID_LENGTH")
+	// ErrCodeInvalidCharacter is an error code used to imply that an access key has non-numeric character(s)
+	ErrCodeInvalidCharacter = errors.Code("INVALID_CHARACTER")
+	// ErrCodeInvalidUF is an error code used to imply that an access key does not contain a valid IBGE UF code
+	ErrCodeInvalidUF = errors.Code("INVALID_UF")
+	// ErrCodeInvalidMonth is an error code used to imply that an access key does not contain a month value between 01-12
+	ErrCodeInvalidMonth = errors.Code("INVALID_MONTH")
+	// ErrCodeInvalidCPFCNPJ is an error code used to imply that an access key does not contain a valid CNPJ
+	ErrCodeInvalidCPFCNPJ = errors.Code("INVALID_CPF_CNPJ")
+	// ErrCodeInvalidModel is an error code used to imply that an access key does not contain a valid SEFAZ model
+	ErrCodeInvalidModel = errors.Code("INVALID_MODEL")
+	// ErrCodeInvalidDigit is an error code used to imply that an access has a verification digit mismatch
+	ErrCodeInvalidDigit = errors.Code("INVALID_DIGIT")
 
 	// ErrEmptyAccessKey is returned when the provided access key is an empty string
 	ErrEmptyAccessKey = errors.New("access key is empty")
-	// ErrInvalidLenght the access key does not contains 44 digits
+	// ErrInvalidLength the access key does not contains 44 digits
+	ErrInvalidLength = errors.New("access key does not have 44 characters")
+	// Deprecated: prefer ErrInvalidLength
 	ErrInvalidLenght = errors.New("access key does not have 44 characters")
 	// ErrInvalidCharacter the access key has non-numeric character(s)
 	ErrInvalidCharacter = errors.New("access key contains non-number characters")

--- a/sefaz/accesskey/validation.go
+++ b/sefaz/accesskey/validation.go
@@ -5,45 +5,72 @@ import (
 	"github.com/arquivei/foundationkit/sefaz/stakeholder"
 )
 
-// validate execute all sub-routines necessary to perform a full accesskey validation
-func validate(accessKey AccessKey) error {
-	const op errors.Op = "validate"
-	if accessKey == "" {
-		return errors.E(op, ErrEmptyAccessKey, ErrCodeEmptyAccessKey)
-	}
-	if len(accessKey) != 44 {
-		return errors.E(op, ErrInvalidLenght, ErrCodeInvalidAccessKey)
-	}
+// Check checks if an access key is valid. It returns an error with an specific code based on
+// the validation problem
+func Check(accessKey AccessKey) error {
+	const op errors.Op = "accesskey.Check"
 
-	if !isDigitOnly(accessKey) {
-		return errors.E(op, ErrInvalidCharacter, ErrCodeInvalidAccessKey)
-	}
-
-	if !isValidUF(accessKey[0:2].String()) {
-		return errors.E(op, ErrInvalidUF, ErrCodeInvalidAccessKey)
-	}
-
-	if !isValidMonth(accessKey[4:6].String()) {
-		return errors.E(op, ErrInvalidMonth, ErrCodeInvalidAccessKey)
-	}
-
-	if !isValidCPFCNPJ(accessKey[6:20].String()) {
-		return errors.E(op, ErrInvalidCPFCNPJ, ErrCodeInvalidAccessKey)
-	}
-
-	if !isValidModel(accessKey[20:22].String()) {
-		return errors.E(op, ErrInvalidModel, ErrCodeInvalidAccessKey)
-	}
-
-	if !isValidationDigitCorrect(accessKey.String()) {
-		return errors.E(op, ErrInvalidDigit, ErrCodeInvalidAccessKey)
+	err := validate(accessKey)
+	if err != nil {
+		return errors.E(op, err)
 	}
 
 	return nil
 }
 
+// validate execute all sub-routines necessary to perform a full accesskey validation
+func validate(accessKey AccessKey) error {
+	const op errors.Op = "validate"
+
+	if accessKey == "" {
+		return errors.E(op, ErrEmptyAccessKey, ErrCodeEmptyAccessKey)
+	}
+
+	if len(accessKey) != 44 {
+		return errors.E(op, ErrInvalidLength, ErrCodeInvalidLength)
+	}
+
+	if !isDigitOnly(accessKey) {
+		return errors.E(op, ErrInvalidCharacter, ErrCodeInvalidCharacter)
+	}
+
+	if !isValidUF(accessKey[0:2].String()) {
+		return errors.E(op, ErrInvalidUF, ErrCodeInvalidUF)
+	}
+
+	if !isValidMonth(accessKey[4:6].String()) {
+		return errors.E(op, ErrInvalidMonth, ErrCodeInvalidMonth)
+	}
+
+	if !isValidCPFCNPJ(accessKey[6:20].String()) {
+		return errors.E(op, ErrInvalidCPFCNPJ, ErrCodeInvalidCPFCNPJ)
+	}
+
+	if !isValidModel(accessKey[20:22].String()) {
+		return errors.E(op, ErrInvalidModel, ErrCodeInvalidModel)
+	}
+
+	if !isValidationDigitCorrect(accessKey.String()) {
+		return errors.E(op, ErrInvalidDigit, ErrCodeInvalidDigit)
+	}
+
+	return nil
+}
+
+// Deprecated: prefer using the Check function
 func (v *validator) Check(accessKey AccessKey) error {
-	return validate(accessKey)
+	const op errors.Op = "accesskey.validator.Check"
+
+	err := validate(accessKey)
+	if err == nil {
+		return nil
+	}
+
+	if code := errors.GetCode(err); code != ErrCodeEmptyAccessKey && code != ErrCodeInvalidAccessKey {
+		return errors.E(op, err, ErrCodeInvalidAccessKey)
+	}
+
+	return errors.E(op, err)
 }
 
 func isDigitOnly(accesskey AccessKey) bool {

--- a/sefaz/accesskey/validation_test.go
+++ b/sefaz/accesskey/validation_test.go
@@ -1,0 +1,69 @@
+package accesskey
+
+import (
+	"testing"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheck_ShouldReturnNilForValidAccessKeys(t *testing.T) {
+	key := AccessKey("35190901180169000133550010000297701022024512")
+
+	err := Check(key)
+
+	assert.Nil(t, err)
+}
+
+func TestCheck_ShouldReturnValidationCodes(t *testing.T) {
+	tests := map[string]struct {
+		key          AccessKey
+		expectedCode errors.Code
+	}{
+		"Empty access key": {
+			key:          "",
+			expectedCode: ErrCodeEmptyAccessKey,
+		},
+		"Invalid length": {
+			key:          "351909011801690001335500100002",
+			expectedCode: ErrCodeInvalidLength,
+		},
+		"Non numeric key": {
+			key:          "3519O901180169O00133550010000297701022024512",
+			expectedCode: ErrCodeInvalidCharacter,
+		},
+		"Invalid UF": {
+			key:          "95190901180169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidUF,
+		},
+		"Invalid month": {
+			key:          "35194201180169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidMonth,
+		},
+		"Invalid CPF": {
+			key:          "42160300005475399984558910004353741212308338",
+			expectedCode: ErrCodeInvalidCPFCNPJ,
+		},
+		"Invalid CNPJ": {
+			key:          "35190901429169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidCPFCNPJ,
+		},
+		"Invalid model": {
+			key:          "35190901180169000133420010000297701022024512",
+			expectedCode: ErrCodeInvalidModel,
+		},
+		"Invalid digit": {
+			key:          "35190901180169000133550010000297701022024513",
+			expectedCode: ErrCodeInvalidDigit,
+		},
+	}
+
+	for testName, testCase := range tests {
+		err := Check(testCase.key)
+		code := errors.GetCode(err)
+
+		if code != testCase.expectedCode {
+			t.Errorf("Wrong validation for key '%s', expected an '%s' error", testCase.key, testName)
+		}
+	}
+}

--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -42,7 +42,7 @@ func (c CUF) String() string {
 	return strconv.Itoa(int(c.value))
 }
 
-//MarshalJSON serializes the CUF value as a JSON value
+// MarshalJSON serializes the CUF value as a JSON value
 func (c CUF) MarshalJSON() ([]byte, error) {
 	const op = errors.Op("CUF.MarshalJSON")
 
@@ -52,7 +52,7 @@ func (c CUF) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 
-//UnmarshalJSON deserialize a JSON value into a CUF value
+// UnmarshalJSON deserialize a JSON value into a CUF value
 func (c *CUF) UnmarshalJSON(b []byte) error {
 	const op = errors.Op("CUF.UnmarshalJSON")
 	var v string

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -16,7 +16,7 @@ func (nsu NSU) String() string {
 	return fmt.Sprintf("%015s", string(nsu))
 }
 
-//MarshalJSON serializes the NSU value as a JSON value
+// MarshalJSON serializes the NSU value as a JSON value
 func (nsu NSU) MarshalJSON() ([]byte, error) {
 	// I don't capture the error here and wraps it with op because it's impossible (probably)
 	// that we can reproduce said error in a unit test and we would have some untestable code.
@@ -32,7 +32,7 @@ func (nsu NSU) MarshalJSON() ([]byte, error) {
 	*/
 }
 
-//UnmarshalJSON deserializes a JSON value into a NSU value
+// UnmarshalJSON deserializes a JSON value into a NSU value
 func (nsu *NSU) UnmarshalJSON(b []byte) error {
 	const op = errors.Op("nsu.UnmarshalJSON")
 	var s string

--- a/sefaz/stakeholder/stakeholder.go
+++ b/sefaz/stakeholder/stakeholder.go
@@ -14,12 +14,12 @@ func (s Stakeholder) String() string {
 	return string(s)
 }
 
-//MarshalJSON serializes the stakeholder value as a JSON value
+// MarshalJSON serializes the stakeholder value as a JSON value
 func (s Stakeholder) MarshalJSON() ([]byte, error) {
 	return json.Marshal(string(s))
 }
 
-//UnmarshalJSON deserializes a JSON value into a Stakeholder value
+// UnmarshalJSON deserializes a JSON value into a Stakeholder value
 func (s *Stakeholder) UnmarshalJSON(b []byte) error {
 	const op = errors.Op("stakeholder.UnmarshalJSON")
 	var v string


### PR DESCRIPTION
The current access key validation structure has some flaws:

  - The returned error code does not contain the specific reason about
  why the validation failed, which makes it harder to programmatically
  proccess this information
  - It uses an interface/struct, which can be a little unconveninet for
  the general use, a package function could provide a better developer
  experience.

Create a new accesskey.Check function which returns better description
about the validation issues found through the error code.

Deprecate the accesskey.Validator interface and its implementors and
improve the test coverage.