### PR TITLE
Shorten some trace and request packages functions names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ type Response struct {
 
 #### HTTP Layer
 
-Use the method `request.WithRequestID` to create and put a Request ID in context
+Use the method `request.WithID` to create and put a Request ID in context
 
 ```golang
 func MakeEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, r interface{}) (interface{}, error) {
 		req := r.(Request)
 
-		ctx = request.WithRequestID(ctx)
+		ctx = request.WithID(ctx)
 
 		response, err := s.Do(ctx, req)
 
@@ -43,12 +43,12 @@ func MakeEndpoint(s Service) endpoint.Endpoint {
 
 #### Logging
 
-Use the method `request.GetRequestIDFromContext` to log the Request ID
+Use the method `request.GetIDFromContext` to log the Request ID
 
 ```golang
 func (l *logging) Do(ctx ontext.Context, req Request) (response Response, err error) {
 	logger := log.Logger.With().
-		EmbedObject(request.GetRequestIDFromContext(ctx)).
+		EmbedObject(request.GetIDFromContext(ctx)).
 		Logger()
     // (...)
 }
@@ -169,13 +169,13 @@ func (s service) Do(ctx ontext.Context, req Request) (response Response, err err
     // Make a POST in another service
     var req *http.Request
     prepareRequest(req)
-    trace.SetTraceInHTTPRequest(ctx, req)
+    trace.SetInHTTPRequest(ctx, req)
 
     // Create a job/event to send to a queue
     // or
     // Create the Service Response
-    response.Trace = trace.GetTraceFromContext(ctx)
-    newJob.Trace = trace.GetTraceFromContext(ctx)
+    response.Trace = trace.GetFromContext(ctx)
+    newJob.Trace = trace.GetFromContext(ctx)
 }
 
 func prepareRequest(req *http.Request) {
@@ -201,7 +201,7 @@ func (l *logging) Do(ctx ontext.Context, req Request) (response Response, err er
 ```golang
 func EncodeResponse(ctx context.Context, w http.ResponseWriter, r interface{}) error {
     response := r.(Response)
-    trace.SetTraceInHTTPResponse(response.Trace, w)
+    trace.SetInHTTPResponse(response.Trace, w)
     // (...)
 }
 ```

--- a/gokitmiddlewares/loggingmiddleware/loggercontext.go
+++ b/gokitmiddlewares/loggingmiddleware/loggercontext.go
@@ -33,16 +33,16 @@ func enrichLoggerContext(ctx context.Context, l *zerolog.Logger, c Config, req i
 			zctx = zctx.Interface("request_meta", meta)
 		}
 
-		if rid := request.GetRequestIDFromContext(ctx); !rid.IsEmpty() {
-			zctx = zctx.EmbedObject(request.GetRequestIDFromContext(ctx))
+		if rid := request.GetIDFromContext(ctx); !rid.IsEmpty() {
+			zctx = zctx.EmbedObject(request.GetIDFromContext(ctx))
 		} else {
-			log.Warn().Msg("Request doesn't have a Request ID! Did you forget to use trackingmiddleware on the trasport layer?")
+			log.Warn().Msg("Request doesn't have a Request ID! Did you forget to use trackingmiddleware on the transport layer?")
 		}
 
-		if t := trace.GetTraceFromContext(ctx); !trace.IDIsEmpty(t.ID) {
-			zctx = zctx.EmbedObject(trace.GetTraceFromContext(ctx))
+		if t := trace.GetFromContext(ctx); !trace.IDIsEmpty(t.ID) {
+			zctx = zctx.EmbedObject(trace.GetFromContext(ctx))
 		} else {
-			log.Warn().Msg("Request doesn't have a trace! Did you forget to use trackingmiddleware on the trasport layer?")
+			log.Warn().Msg("Request doesn't have a trace! Did you forget to use trackingmiddleware on the transport layer?")
 		}
 
 		return zctx.Str("endpoint_name", c.Name)

--- a/gokitmiddlewares/trackingmiddleware/middleware.go
+++ b/gokitmiddlewares/trackingmiddleware/middleware.go
@@ -19,7 +19,7 @@ func New() endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, r interface{}) (interface{}, error) {
 			// Ensures that we have a request ID in the context
-			ctx = request.WithNewRequestID(ctx)
+			ctx = request.WithNewID(ctx)
 
 			// Get trace from request if there is one or else
 			// creates a new trace.

--- a/httpcomm/communicatewithjson.go
+++ b/httpcomm/communicatewithjson.go
@@ -178,7 +178,7 @@ func makeHTTPRequest(
 		//         a trace.ExistsInContext(ctx) to allow checking.
 		ctx = trace.WithTrace(ctx, trace.Trace{})
 	}
-	trace.SetTraceInHTTPRequest(ctx, httpRequest)
+	trace.SetInHTTPRequest(ctx, httpRequest)
 
 	// NOTE : it is proposed that RequestID can be sent over HTTP Requests so that the receiver
 	// side (the server) can log it; but not use it. This can aid in backtracking request is
@@ -212,7 +212,7 @@ func communicateWithHTTPRequest(
 	}
 
 	defer httpResponse.Body.Close()
-	details.Trace = trace.GetTraceFromHTTPResponse(httpResponse)
+	details.Trace = trace.GetFromHTTPResponse(httpResponse)
 	details.RequestID = request.GetFromHTTPResponse(httpResponse)
 
 	limitedReader := io.LimitReader(httpResponse.Body, maxAcceptedBodySize+1)

--- a/httpcomm/communicatewithjson_test.go
+++ b/httpcomm/communicatewithjson_test.go
@@ -31,21 +31,21 @@ func Test_communicateWithJSON_Success(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = trace.WithNewTrace(ctx)
-	requestTrace := trace.GetTraceFromContext(ctx)
+	requestTrace := trace.GetFromContext(ctx)
 
 	var serverRequestID request.ID
 
 	testServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			receivedTrace := trace.GetTraceFromHTTPRequest(r)
+			receivedTrace := trace.GetFromHTTPRequest(r)
 
 			// Casting traces to String so assertion message is friendlier to human eyes
 			assert.Equal(t, requestTrace.ID.String(), receivedTrace.ID.String(), "server trace id")
 			assert.Equal(t, requestTrace.ProbabilitySample, receivedTrace.ProbabilitySample, "server trace probability sample")
 
 			// TODO : need a request.NewID() method to avoid using context like this in tests
-			serverRequestID = request.GetRequestIDFromContext(request.WithNewRequestID(context.Background()))
-			trace.SetTraceInHTTPResponse(receivedTrace, w)
+			serverRequestID = request.GetIDFromContext(request.WithNewID(context.Background()))
+			trace.SetInHTTPResponse(receivedTrace, w)
 			request.SetInHTTPResponse(serverRequestID, w)
 
 			// NOTE : theres no implementation to send request id over http response yet

--- a/httpmiddlewares/trackingmiddleware/middleware.go
+++ b/httpmiddlewares/trackingmiddleware/middleware.go
@@ -11,11 +11,11 @@ import (
 func New(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		ctx = request.WithNewRequestID(ctx)
-		ctx = trace.WithTrace(ctx, trace.GetTraceFromHTTPRequest(r))
+		ctx = request.WithNewID(ctx)
+		ctx = trace.WithTrace(ctx, trace.GetFromHTTPRequest(r))
 
-		request.SetInHTTPResponse(request.GetRequestIDFromContext(ctx), w)
-		trace.SetTraceInHTTPResponse(trace.GetTraceFromContext(ctx), w)
+		request.SetInHTTPResponse(request.GetIDFromContext(ctx), w)
+		trace.SetInHTTPResponse(trace.GetFromContext(ctx), w)
 
 		r = r.WithContext(ctx)
 		next.ServeHTTP(w, r)

--- a/request/context.go
+++ b/request/context.go
@@ -8,26 +8,50 @@ const (
 	contextKeyID contextKeyType = iota
 )
 
-// WithRequestID returns a context with the given ID
+// WithID returns a context with the given ID
 //
 // If there is already an ID in the context, the context is returned unchanged.
-func WithRequestID(ctx context.Context, id ID) context.Context {
+func WithID(ctx context.Context, id ID) context.Context {
 	if v := ctx.Value(contextKeyID); v == nil {
 		return context.WithValue(ctx, contextKeyID, id)
 	}
 	return ctx
 }
 
-// WithNewRequestID calls WithRequestIDpassign a new ID
-func WithNewRequestID(ctx context.Context) context.Context {
-	return WithRequestID(ctx, newID())
+// WithRequestID returns a context with the given ID
+//
+// If there is already an ID in the context, the context is returned unchanged.
+//
+// Deprecated: use WithID instead
+func WithRequestID(ctx context.Context, id ID) context.Context {
+	return WithID(ctx, id)
 }
 
-// GetRequestIDFromContext returns the request ID in the context.
+// WithNewID calls WithID with a new ID
+func WithNewID(ctx context.Context) context.Context {
+	return WithID(ctx, newID())
+}
+
+// WithNewRequestID calls WithNewID
+//
+// Deprecated: use WithNewID instead
+func WithNewRequestID(ctx context.Context) context.Context {
+	return WithNewID(ctx)
+}
+
+// GetIDFromContext returns the request ID in the context.
 // Will return a empty ID if it is not set
-func GetRequestIDFromContext(ctx context.Context) ID {
+func GetIDFromContext(ctx context.Context) ID {
 	if id, ok := ctx.Value(contextKeyID).(ID); ok {
 		return id
 	}
 	return ID{}
+}
+
+// GetRequestIDFromContext returns the request ID in the context.
+// Will return a empty ID if it is not set
+//
+// Deprecated: use GetIDFromContext instead
+func GetRequestIDFromContext(ctx context.Context) ID {
+	return GetIDFromContext(ctx)
 }

--- a/request/context_test.go
+++ b/request/context_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestIDContextOperations(t *testing.T) {
 	ctx := context.Background()
-	assert.Empty(t, GetRequestIDFromContext(ctx))
+	assert.Empty(t, GetIDFromContext(ctx))
 
-	ctx = WithNewRequestID(ctx)
-	assert.NotEmpty(t, GetRequestIDFromContext(ctx))
+	ctx = WithNewID(ctx)
+	assert.NotEmpty(t, GetIDFromContext(ctx))
 }

--- a/request/http.go
+++ b/request/http.go
@@ -37,7 +37,7 @@ func SetInHTTPRequest(ctx context.Context, request *http.Request) {
 		return
 	}
 
-	id := GetRequestIDFromContext(ctx)
+	id := GetIDFromContext(ctx)
 	request.Header.Set(HTTPHeaderID, id.String())
 }
 

--- a/request/http_test.go
+++ b/request/http_test.go
@@ -30,7 +30,7 @@ func TestSetInHTTPRequest(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
-	SetInHTTPRequest(WithRequestID(context.Background(), id), r)
+	SetInHTTPRequest(WithID(context.Background(), id), r)
 
 	assert.Equal(t, id.String(), r.Header.Get(HTTPHeaderID))
 }
@@ -39,7 +39,7 @@ func TestSetInHTTPRequest_EmptyID(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
-	SetInHTTPRequest(WithRequestID(context.Background(), ID{}), r)
+	SetInHTTPRequest(WithID(context.Background(), ID{}), r)
 
 	assert.Empty(t, r.Header.Get(HTTPHeaderID))
 }

--- a/trace/context.go
+++ b/trace/context.go
@@ -31,15 +31,22 @@ func WithNewTrace(ctx context.Context) context.Context {
 	return WithTrace(ctx, Trace{})
 }
 
-// GetTraceFromContext returns the Trace saved in @ctx
-func GetTraceFromContext(ctx context.Context) Trace {
+// GetFromContext returns the Trace saved in @ctx
+func GetFromContext(ctx context.Context) Trace {
 	if t, ok := ctx.Value(contextKeyTrace).(Trace); ok {
 		return t
 	}
 	log.Warn().
-		Str("method", "trace.GetTraceFromContext").
+		Str("method", "trace.GetFromContext").
 		Msg("[FoundationKit] There is no Trace in context. Use trace.WithTrace(context.Context, trace.Trace)")
 	return Trace{}
+}
+
+// GetTraceFromContext returns the Trace saved in @ctx
+//
+// Deprecated: use GetFromContext instead
+func GetTraceFromContext(ctx context.Context) Trace {
+	return GetFromContext(ctx)
 }
 
 // WithLabels returns the @parent context with the labels @labels
@@ -66,7 +73,7 @@ func getLabelsFromContext(ctx context.Context) map[string]string {
 // GetIDFromContext returns the Trace ID in the context.
 // Will return a empty ID if a Trace is not set in context
 func GetIDFromContext(ctx context.Context) ID {
-	return GetTraceFromContext(ctx).ID
+	return GetFromContext(ctx).ID
 }
 
 // WithTraceAndLabels returns the @parent context with the Trace @trace
@@ -87,7 +94,7 @@ func WithTraceID(parent context.Context, traceID ID) context.Context {
 // GetTraceIDFromContext returns the trace ID set in the context, if any,
 // or an empty trace id if none is set
 //
-// Deprecated: Should use GetTraceFromContext instead
+// Deprecated: Should use GetFromContext instead
 func GetTraceIDFromContext(ctx context.Context) ID {
 	if id, ok := ctx.Value(contextKeyTraceID).(ID); ok {
 		return id

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -21,12 +21,12 @@ func TestIDOperations(t *testing.T) {
 
 func TestTraceOperations(t *testing.T) {
 	ctx := context.Background()
-	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
+	assert.True(t, IDIsEmpty(GetFromContext(ctx).ID))
 
 	defaultProbabilitySample = 0.5
 	ctx = WithTrace(ctx, newTrace())
 
-	trace := GetTraceFromContext(ctx)
+	trace := GetFromContext(ctx)
 
 	assert.False(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
@@ -34,7 +34,7 @@ func TestTraceOperations(t *testing.T) {
 
 func TestTraceAndLabelsOperations(t *testing.T) {
 	ctx := context.Background()
-	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
+	assert.True(t, IDIsEmpty(GetFromContext(ctx).ID))
 	assert.Nil(t, getLabelsFromContext(ctx))
 
 	defaultProbabilitySample = 0.5
@@ -43,7 +43,7 @@ func TestTraceAndLabelsOperations(t *testing.T) {
 		"k2": "v2",
 	})
 
-	trace := GetTraceFromContext(ctx)
+	trace := GetFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
 
@@ -62,13 +62,13 @@ func TestTraceAndLabelsOperations(t *testing.T) {
 
 func TestTraceAndLabelsOperations_LabelsNil(t *testing.T) {
 	ctx := context.Background()
-	assert.True(t, IDIsEmpty(GetTraceFromContext(ctx).ID))
+	assert.True(t, IDIsEmpty(GetFromContext(ctx).ID))
 	assert.Nil(t, getLabelsFromContext(ctx))
 
 	defaultProbabilitySample = 0.5
 	ctx = WithTraceAndLabels(ctx, newTrace(), nil)
 
-	trace := GetTraceFromContext(ctx)
+	trace := GetFromContext(ctx)
 	assert.False(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, defaultProbabilitySample, *trace.ProbabilitySample)
 
@@ -105,7 +105,7 @@ func TestTraceIDContextOperations(t *testing.T) {
 	ctx := context.Background()
 	assert.True(t, IDIsEmpty(GetTraceIDFromContext(ctx)))
 
-	id := NewTraceID()
+	id := NewID()
 	ctx = WithTraceID(ctx, id)
 	assert.Equal(t, id.String(), GetTraceIDFromContext(ctx).String())
 }

--- a/trace/http.go
+++ b/trace/http.go
@@ -14,9 +14,9 @@ const (
 	headerProbabilitySample = "X-PROBABILITYSAMPLE"
 )
 
-// GetTraceFromHTTPRequest returns a Trace using the trace
+// GetFromHTTPRequest returns a Trace using the trace
 // ID and the probability sample get from the header of @r
-func GetTraceFromHTTPRequest(r *http.Request) Trace {
+func GetFromHTTPRequest(r *http.Request) Trace {
 	idStr := r.Header.Get(headerTraceID)
 	id := decode([]byte(idStr))
 
@@ -34,24 +34,40 @@ func GetTraceFromHTTPRequest(r *http.Request) Trace {
 	}
 }
 
-// SetTraceInHTTPRequest sets the header of @request using the
+// GetTraceFromHTTPRequest returns a Trace using the trace
+// ID and the probability sample get from the header of @r
+//
+// Deprecated: use GetFromHTTPRequest
+func GetTraceFromHTTPRequest(r *http.Request) Trace {
+	return GetFromHTTPRequest(r)
+}
+
+// SetInHTTPRequest sets the header of @request using the
 // trace in the @ctx. If @trace is empty or @request is nil, nothing will happen
-func SetTraceInHTTPRequest(ctx context.Context, request *http.Request) {
+func SetInHTTPRequest(ctx context.Context, request *http.Request) {
 	if request == nil {
 		log.Warn().
-			Str("method", "trace.SetTraceInHTTPRequest").
+			Str("method", "trace.SetInHTTPRequest").
 			Msg("[FoundationKit] Request is nil. Nothing will happen")
 		return
 	}
 
-	trace := GetTraceFromContext(ctx)
+	trace := GetFromContext(ctx)
 	request.Header.Set(headerTraceID, trace.ID.String())
 	request.Header.Set(headerProbabilitySample, fmt.Sprintf("%f", *trace.ProbabilitySample))
 }
 
-// GetTraceFromHTTPResponse returns a Trace using the trace
+// SetTraceInHTTPRequest sets the header of @request using the
+// trace in the @ctx. If @trace is empty or @request is nil, nothing will happen
+//
+// Deprecated: use SetInHTTPRequest instead
+func SetTraceInHTTPRequest(ctx context.Context, request *http.Request) {
+	SetInHTTPRequest(ctx, request)
+}
+
+// GetFromHTTPResponse returns a Trace using the trace
 // ID and the probability sample get from the header of @r
-func GetTraceFromHTTPResponse(r *http.Response) Trace {
+func GetFromHTTPResponse(r *http.Response) Trace {
 	idStr := r.Header.Get(headerTraceID)
 	id := decode([]byte(idStr))
 
@@ -69,12 +85,20 @@ func GetTraceFromHTTPResponse(r *http.Response) Trace {
 	}
 }
 
-// SetTraceInHTTPResponse sets the header of @response using @trace.
+// GetTraceFromHTTPResponse returns a Trace using the trace
+// ID and the probability sample get from the header of @r
+//
+// Deprecated: use GetFromHTTPResponse instead
+func GetTraceFromHTTPResponse(r *http.Response) Trace {
+	return GetFromHTTPResponse(r)
+}
+
+// SetInHTTPResponse sets the header of @response using @trace.
 // If @trace is empty or @response is nil, nothing will happen
-func SetTraceInHTTPResponse(trace Trace, response http.ResponseWriter) {
+func SetInHTTPResponse(trace Trace, response http.ResponseWriter) {
 	if response == nil {
 		log.Warn().
-			Str("method", "trace.SetTraceInHTTPResponse").
+			Str("method", "trace.SetInHTTPResponse").
 			Msg("[FoundationKit] Response is nil. Nothing will happen")
 		return
 	}
@@ -87,9 +111,18 @@ func SetTraceInHTTPResponse(trace Trace, response http.ResponseWriter) {
 	response.Header().Set(headerProbabilitySample, fmt.Sprintf("%f", *trace.ProbabilitySample))
 }
 
+// SetTraceInHTTPResponse sets the header of @response using @trace.
+// If @trace is empty or @response is nil, nothing will happen
+//
+// Deprecated: use SetInHTTPResponse instead
+func SetTraceInHTTPResponse(trace Trace, response http.ResponseWriter) {
+	SetInHTTPResponse(trace, response)
+}
+
 // GetTraceIDFromHTTPRequest attempts to return a trace ID read from the @r
 // http request by obtaining the value in the `X-TRACEID` http header field.
-// [DEPRECATED] Should use GetTraceFromHTTRequest instead
+//
+// Deprecated: should use GetFromHTTRequest instead
 func GetTraceIDFromHTTPRequest(r *http.Request) ID {
 	s := r.Header.Get("X-TRACEID")
 	return decode([]byte(s))

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -10,67 +10,67 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetTraceFromHTTPRequest(t *testing.T) {
+func TestGetFromHTTPRequest(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := GetTraceFromHTTPRequest(r)
+	trace := GetFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTPRequest_ErrorParseProbabilitySample(t *testing.T) {
+func TestGetFromHTTPRequest_ErrorParseProbabilitySample(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 	r.Header.Add(headerProbabilitySample, "0.5a")
 
-	trace := GetTraceFromHTTPRequest(r)
+	trace := GetFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTPRequest_WithoutHeader(t *testing.T) {
+func TestGetFromHTTPRequest_WithoutHeader(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
-	trace := GetTraceFromHTTPRequest(r)
+	trace := GetFromHTTPRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTPRequest_WithoutProbabilitySample(t *testing.T) {
+func TestGetFromHTTPRequest_WithoutProbabilitySample(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerTraceID, "00000000000000000000000000000019")
 
-	trace := GetTraceFromHTTPRequest(r)
+	trace := GetFromHTTPRequest(r)
 
 	assert.Equal(t, "00000000000000000000000000000019", trace.ID.String())
 	assert.Nil(t, trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTPRequest_WithoutTraceID(t *testing.T) {
+func TestGetFromHTTPRequest_WithoutTraceID(t *testing.T) {
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
 
 	r.Header.Add(headerProbabilitySample, "0.5")
 
-	trace := GetTraceFromHTTPRequest(r)
+	trace := GetFromHTTPRequest(r)
 
 	assert.True(t, IDIsEmpty(trace.ID))
 	assert.Equal(t, 0.5, *trace.ProbabilitySample)
 }
 
-func TestGetTraceFromHTTPResponse(t *testing.T) {
+func TestGetFromHTTPResponse(t *testing.T) {
 	ps := 0.75
 	trace := Trace{
 		ID:                decode([]byte("000000000000000000000000bebacafe")),
@@ -86,7 +86,7 @@ func TestGetTraceFromHTTPResponse(t *testing.T) {
 	assert.Equal(t, "0.750000", fmt.Sprintf("%f", *trace.ProbabilitySample))
 }
 
-func TestSetTraceInHTTPResponse(t *testing.T) {
+func TestSetInHTTPResponse(t *testing.T) {
 	ps := 0.5
 	trace := Trace{
 		ID:                decode([]byte("00000000000000000000000000000019")),
@@ -94,48 +94,48 @@ func TestSetTraceInHTTPResponse(t *testing.T) {
 	}
 
 	r := httptest.NewRecorder()
-	SetTraceInHTTPResponse(trace, r)
+	SetInHTTPResponse(trace, r)
 
 	assert.Equal(t, "00000000000000000000000000000019", r.Header().Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPResponse_EmptyTrace(t *testing.T) {
+func TestSetInHTTPResponse_EmptyTrace(t *testing.T) {
 	defaultProbabilitySample = 0.5
 	r := httptest.NewRecorder()
-	SetTraceInHTTPResponse(Trace{}, r)
+	SetInHTTPResponse(Trace{}, r)
 
 	assert.NotEmpty(t, r.Header().Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPResponse_EmptyProbabilitySample(t *testing.T) {
+func TestSetInHTTPResponse_EmptyProbabilitySample(t *testing.T) {
 	defaultProbabilitySample = 0.5
 	trace := Trace{
 		ID: decode([]byte("00000000000000000000000000000019")),
 	}
 
 	r := httptest.NewRecorder()
-	SetTraceInHTTPResponse(trace, r)
+	SetInHTTPResponse(trace, r)
 
 	assert.Equal(t, "00000000000000000000000000000019", r.Header().Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPResponse_EmptyTraceID(t *testing.T) {
+func TestSetInHTTPResponse_EmptyTraceID(t *testing.T) {
 	ps := 0.5
 	trace := Trace{
 		ProbabilitySample: &ps,
 	}
 
 	r := httptest.NewRecorder()
-	SetTraceInHTTPResponse(trace, r)
+	SetInHTTPResponse(trace, r)
 
 	assert.NotEmpty(t, r.Header().Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header().Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPRequest(t *testing.T) {
+func TestSetInHTTPRequest(t *testing.T) {
 	ps := 0.5
 	trace := Trace{
 		ID:                decode([]byte("00000000000000000000000000000019")),
@@ -144,23 +144,23 @@ func TestSetTraceInHTTPRequest(t *testing.T) {
 
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
-	SetTraceInHTTPRequest(WithTrace(context.Background(), trace), r)
+	SetInHTTPRequest(WithTrace(context.Background(), trace), r)
 
 	assert.Equal(t, "00000000000000000000000000000019", r.Header.Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPRequest_EmptyTrace(t *testing.T) {
+func TestSetInHTTPRequest_EmptyTrace(t *testing.T) {
 	defaultProbabilitySample = 0.5
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
-	SetTraceInHTTPRequest(WithTrace(context.Background(), Trace{}), r)
+	SetInHTTPRequest(WithTrace(context.Background(), Trace{}), r)
 
 	assert.NotEmpty(t, r.Header.Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPRequest_EmptyProbabilitySample(t *testing.T) {
+func TestSetInHTTPRequest_EmptyProbabilitySample(t *testing.T) {
 	defaultProbabilitySample = 0.5
 	trace := Trace{
 		ID: decode([]byte("00000000000000000000000000000019")),
@@ -168,13 +168,13 @@ func TestSetTraceInHTTPRequest_EmptyProbabilitySample(t *testing.T) {
 
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
-	SetTraceInHTTPRequest(WithTrace(context.Background(), trace), r)
+	SetInHTTPRequest(WithTrace(context.Background(), trace), r)
 
 	assert.Equal(t, "00000000000000000000000000000019", r.Header.Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))
 }
 
-func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
+func TestSetInHTTPRequest_EmptyTraceID(t *testing.T) {
 	ps := 0.5
 	trace := Trace{
 		ProbabilitySample: &ps,
@@ -182,7 +182,7 @@ func TestSetTraceInHTTPRequest_EmptyTraceID(t *testing.T) {
 
 	r, err := http.NewRequestWithContext(context.Background(), "POST", "URL", nil)
 	assert.NoError(t, err)
-	SetTraceInHTTPRequest(WithTrace(context.Background(), trace), r)
+	SetInHTTPRequest(WithTrace(context.Background(), trace), r)
 
 	assert.NotEmpty(t, r.Header.Get(headerTraceID))
 	assert.Equal(t, "0.500000", r.Header.Get(headerProbabilitySample))

--- a/trace/id.go
+++ b/trace/id.go
@@ -76,12 +76,19 @@ func (id ID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(id.String())
 }
 
-// NewTraceID generates a new random trace id
-func NewTraceID() ID {
+// NewID generates a new random trace id
+func NewID() ID {
 	return traceIDGen.NewTraceID()
 }
 
-// EnsureIDNotEmpty checks if the ID is not empty and return it, else it returns NewTraceID().
+// NewTraceID generates a new random trace id
+//
+// Deprecated: use NewID instead
+func NewTraceID() ID {
+	return NewID()
+}
+
+// EnsureIDNotEmpty checks if the ID is not empty and return it, else it returns NewID().
 // The empty check follows the same rules as the IDIsEmpty function.
 func EnsureIDNotEmpty(id ID) ID {
 	if IDIsEmpty(id) {

--- a/trace/id_test.go
+++ b/trace/id_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestTraceIDGeneration(t *testing.T) {
 	// Should generate random non-empty traceIDs
-	id1 := NewTraceID()
-	id2 := NewTraceID()
+	id1 := NewID()
+	id2 := NewID()
 	assert.False(t, IDIsEmpty(id1))
 	assert.False(t, IDIsEmpty(id2))
 	assert.NotEqual(t, id1, id2)

--- a/trace/span.go
+++ b/trace/span.go
@@ -27,7 +27,7 @@ func (s *Span) End(err error) {
 // If exists a Trace in @ctx, the method will return a span with it as parent.
 // Otherwise, the method will create a new span and return it
 func StartSpanWithParent(ctx context.Context, spanNameArgs ...string) (newCtx context.Context, s Span) {
-	t := GetTraceFromContext(ctx)
+	t := GetFromContext(ctx)
 
 	parent := createSpanContext(t.ID.String(), *t.ProbabilitySample)
 

--- a/trace/span_test.go
+++ b/trace/span_test.go
@@ -28,7 +28,7 @@ func TestSpan(t *testing.T) {
 			name:                     "With Parent with PS = 1 and DPS = 0; Should Sample",
 			defaultProbabilitySample: 0,
 			parent: Trace{
-				ID:                NewTraceID(),
+				ID:                NewID(),
 				ProbabilitySample: &one,
 			},
 			expectedIsSample: true,
@@ -37,7 +37,7 @@ func TestSpan(t *testing.T) {
 			name:                     "With Parent with PS = 0 and DPS = 1; Should not Sample",
 			defaultProbabilitySample: 1,
 			parent: Trace{
-				ID:                NewTraceID(),
+				ID:                NewID(),
 				ProbabilitySample: &zero,
 			},
 			expectedIsSample: false,
@@ -46,7 +46,7 @@ func TestSpan(t *testing.T) {
 			name:                     "With Parent with PS = 1 and DPS = nil; Should Sample",
 			defaultProbabilitySample: -1,
 			parent: Trace{
-				ID:                NewTraceID(),
+				ID:                NewID(),
 				ProbabilitySample: &one,
 			},
 			expectedIsSample: true,
@@ -55,7 +55,7 @@ func TestSpan(t *testing.T) {
 			name:                     "With Parent with PS = 0 and DPS = nil; Should not Sample",
 			defaultProbabilitySample: -1,
 			parent: Trace{
-				ID:                NewTraceID(),
+				ID:                NewID(),
 				ProbabilitySample: &zero,
 			},
 			expectedIsSample: false,
@@ -93,7 +93,7 @@ func assertResponse(ctx context.Context, s Span, test testSpan, t *testing.T) {
 		assert.Equal(t, test.parent.ID.String(), s.span.SpanContext().TraceID.String(), fmt.Sprintf("trace ID not equal [%s]", test.name))
 	}
 
-	trace := GetTraceFromContext(ctx)
+	trace := GetFromContext(ctx)
 	if !assert.NotNil(t, trace, fmt.Sprintf("trace should not be nil [%s]", test.name)) {
 		return
 	}
@@ -123,7 +123,7 @@ func assertResponse(ctx context.Context, s Span, test testSpan, t *testing.T) {
 }
 
 func TestCreateSampleContext(t *testing.T) {
-	traceID := NewTraceID()
+	traceID := NewID()
 	span0 := createSpanContext(traceID.String(), 0)
 	span1 := createSpanContext(traceID.String(), 1)
 

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -14,7 +14,7 @@ type Trace struct {
 
 func newTrace() Trace {
 	return Trace{
-		ID:                NewTraceID(),
+		ID:                NewID(),
 		ProbabilitySample: &defaultProbabilitySample,
 	}
 }
@@ -25,7 +25,7 @@ func (t Trace) isEmpty() bool {
 
 func ensureTraceNotEmpty(t Trace) Trace {
 	if IDIsEmpty(t.ID) {
-		t.ID = NewTraceID()
+		t.ID = NewID()
 	}
 	if t.ProbabilitySample == nil {
 		t.ProbabilitySample = &defaultProbabilitySample

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -18,7 +18,7 @@ type traceTest struct {
 
 func TestEnsureTraceNotEmpty(t *testing.T) {
 	ps := 1.9
-	newID := NewTraceID()
+	newID := NewID()
 
 	tests := []traceTest{
 		{
@@ -61,7 +61,7 @@ func TestEnsureTraceNotEmpty(t *testing.T) {
 		ctx := WithTrace(context.Background(), test.trace)
 		assertTrace(t, test, "Trace from Test")
 
-		traceFromCtx := GetTraceFromContext(ctx)
+		traceFromCtx := GetFromContext(ctx)
 		test.trace = traceFromCtx
 		assertTrace(t, test, "Trace from Context")
 	}

--- a/trace/zerolog_test.go
+++ b/trace/zerolog_test.go
@@ -14,7 +14,7 @@ func TestNotPanicMarshalZerologObject(t *testing.T) {
 	}{
 		{
 			name: "New ID",
-			id:   NewTraceID(),
+			id:   NewID(),
 		},
 		{
 			name: "Empty ID",


### PR DESCRIPTION
Some functions in the trace and request packages were shortened removing
words such as `Trace` or `Request` where the package name itself would
aid in reading. For example, `request.NewRequestID` can be simplified
to `request.NewID`. All existing functions were kept as deprecated.