### PR TITLE
Upgrade golangci-lint-action version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.31


### PR DESCRIPTION
Golangci-lint is returning error in master. To fix this issue, the
golangci-lint-action version must be upgraded.

Links:

+ https://github.com/golangci/golangci-lint-action/issues/127