### PR TITLE
Refactor app and better probes

### DIFF
--- a/app/default.go
+++ b/app/default.go
@@ -20,8 +20,8 @@ var (
 
 // NewDefaultApp creates and sets the default app. The default app is controlled by
 // public functions in app package
-func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error) {
-	defaultApp, err = New(ctx, DefaultAdminPort, mainLoop)
+func NewDefaultApp(ctx context.Context) (err error) {
+	defaultApp, err = New(ctx, DefaultAdminPort)
 	if err != nil {
 		return err
 	}
@@ -31,11 +31,11 @@ func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error) {
 }
 
 // RunAndWait calls the RunAndWait of the default app
-func RunAndWait() {
+func RunAndWait(f MainLoopFunc) {
 	if defaultApp == nil {
 		panic("default app not initialized")
 	}
-	defaultApp.RunAndWait()
+	defaultApp.RunAndWait(f)
 }
 
 // Shutdown calls the Shutdown of the default app
@@ -54,32 +54,18 @@ func RegisterShutdownHandler(sh *ShutdownHandler) {
 	defaultApp.RegisterShutdownHandler(sh)
 }
 
-// IsReady returns if the default app is ready (to be used by kubernetes readyness probe)
-func IsReady() bool {
-	return defaultApp.Ready
+// ReadinessProbeGoup TODO
+func ReadinessProbeGoup() *ProbeGroup {
+	if defaultApp == nil {
+		panic("default app not initialized")
+	}
+	return &defaultApp.Ready
 }
 
-// SetReady sets the app to ready state
-func SetReady() {
-	defaultApp.Ready = true
-}
-
-// SetUnready sets the app to unready state
-func SetUnready() {
-	defaultApp.Ready = false
-}
-
-// IsHealthy returns if the app is healthy. Unhealthy apps are killed by the kubernetes.
-func IsHealthy() bool {
-	return defaultApp.Healthy
-}
-
-// SetHealthy sets the app to an healthy state
-func SetHealthy() {
-	defaultApp.Healthy = true
-}
-
-// SetUnhealthy sets the app to an unhealthy state
-func SetUnhealthy() {
-	defaultApp.Healthy = false
+// HealthinessProbeGroup TODO
+func HealthinessProbeGroup() *ProbeGroup {
+	if defaultApp == nil {
+		panic("default app not initialized")
+	}
+	return &defaultApp.Healthy
 }

--- a/app/doc.go
+++ b/app/doc.go
@@ -1,0 +1,100 @@
+/*
+Package app provides an application framework that manages the live cycle of a running application.
+
+An app could be an HTTP server (or any kind of server), a worker or a simple program. Independently of the kind of the app, it always exposes an admin port at 9000 by default which serves metrics, debug information and kubernetes probes. It also is capable of graceful shutdown on receiving signals of terminating by itself.
+
+The recommended way to use the `app` package is to rely on the 'default app'. The 'default app' is a global app that can be accessed by public functions on the app package (the app package can be seen as the application)
+
+There is a running example on `app/examples/servefiles`
+
+Basics
+
+The first thing you should do is setup a configuration and logger. The app uses the foundation's kit log package and expects a zerolog's logger in the context.
+
+	app.SetupConfig(&config)
+	ctx := log.SetupLoggerWithContext(context.Background(), config.Log, version)
+	app.NewDefaultApp(ctx)
+
+At this point, the app will already be exposing the admin port and the readiness probe will be returning error, indicating that the application is not yet ready to receive requests.
+
+Then you should start initializing all the program dependencies. Because the application is not yet ready, kubernetes will refrain from sending requests (that would fail at this point). Also we already have some metrics and the debug handlers.
+
+During this phase, you will probably want to register your shutdown handlers.
+
+	app.RegisterShutdownHandler(
+		&app.ShutdownHandler{
+			Name:     "http_server",
+			Priority: app.ShutdownPriority(100),
+			Handler:  httpServer.Shutdown,
+			Policy:   app.ErrorPolicyAbort,
+		},
+	)
+
+They are executed in order by priority. The Highest priority first (in case of the same priority, don't assume any order).
+
+Finally you can run the application by calling RunAndWait:
+
+	app.RunAndWait(func() error {
+		return httpServer.ListenAndServe()
+	})
+
+At this point the application will run until the given function returns or it receives an termination signal.
+
+Updating From Previous Version
+
+On the previous version,the NewDefaultApp received the main loop:
+
+   func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error)
+
+This was a problem because the main loop normally depends on various resources that must be created before the main loop can be called. But the creation of this resourced involves registering shutdown handlers, that requires an already created app.
+
+This cycle forced the application to rely on lazy initialization of the resources. Lazy initialization is not a bad thing but in this particular case this means that when we call RunAndWait and the readiness probe is set return success, the application is still initializing and could start receiving requests before it was really ready.
+
+To break this cycle the main loop was moved from the NewDefaultApp and was placed on the RunAndWait function. So to update to this version you could only change these two functions calls. But, to really take advantage of this new way to start an app, you should refactor the code to remove the laziness part before the RunAndWait is called.
+
+Using Probes
+
+A Probe is a boolean that indicates if something is OK or not. There are two groups of probes in an app: The Healthiness an Readiness groups. Kubernetes checks on there two probes to decide what to do to the pod, like, from stop sending requests to just kill the pod, sending a signal the app will capture and start a graceful shutdown.
+
+If a single probe of a group is not ok, than the whole group is not ok. In this event, the HTTP handler returns the name of all the probes that are not ok for the given group.
+
+	mux.HandleFunc("/healthy", func(w http.ResponseWriter, _ *http.Request) {
+		isHealthy, cause := app.Healthy.CheckProbes()
+		if isHealthy {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(cause))
+		}
+	})
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		isReady, cause := app.Ready.CheckProbes()
+		if isReady {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("OK"))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(cause))
+		}
+	})
+
+
+If the application is unhealthy kubernetes will send a signal that will trigger the graceful shutdown. All registered shutdown handlers will be executed ordered by priority (highest first) and the pod will be restarted. Only set an application as unhealthy if it reached an unworkable state and should be restarted. We have an example of this on `gokitmiddlewares/stalemiddleware/`. This is a middleware that was developed to be used in workers. It checks if the endpoint is being called (messages are being fetched and processed) and if not, it assumes there could be a problem with the queue and sets the application to unready, causing the application to restart. This mitigated a problem we had with kafka when a change of brokers made the worker stop receiving messages forever.
+
+If the application is unready kubernetes will stop sending requests, but if the application becomes ready again, it will start receiving requests. This is used during initialization to signalize to kubernetes when the application is ready and can receive requests. If we can identify that the the application is degraded we can use this probe to temporary remove the application from the kubernetes service until it recovers.
+
+A probe only exists as part of a group so the group provides a proper constructor for a probe. Probe's name must also be unique for the group but can be reused on different groups.
+
+	readinessProbe, err := app.Ready.NewProbe("fkit/app", false)
+	healthnessProbe, err := app.Healthy.NewProbe("fkit/app", true)
+
+The probe is automatically added to the group and any change is automatically reflected on the group it belongs to and the HTTP probe endpoints.
+
+The state of a probe can be altered at any time using SetOk and SetNotOk:
+
+	readinessProbe.SetOk()
+	readinessProbe.SetNotOk()
+
+*/
+package app

--- a/app/examples/servefiles/main.go
+++ b/app/examples/servefiles/main.go
@@ -1,0 +1,54 @@
+package main
+
+// This is an example program on how to use the app package. It uses to FileServer
+// handler to serve all files on a given directory.
+//
+// To run this program in the commandline you could use:
+// go run ./app/examples/servefiles/ -log-human -log-level=debug
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/arquivei/foundationkit/app"
+	"github.com/arquivei/foundationkit/log"
+)
+
+var version = "development" // Should be replaced on compilation phase
+
+var config struct {
+	Log  log.Config
+	HTTP struct {
+		Port string `default:"8000"`
+	}
+	Dir string `default:"."`
+}
+
+func main() {
+	app.SetupConfig(&config)
+	ctx := log.SetupLoggerWithContext(context.Background(), config.Log, version)
+
+	// New app
+	app.NewDefaultApp(ctx)
+
+	// Some inicialization, could take a while.
+	// It's a good practice to initialize everything before calling RunAndWait because
+	// readiness probe is already up and reporting the app is not ready yet.
+	httpServer := &http.Server{Addr: ":" + config.HTTP.Port, Handler: http.FileServer(http.Dir(config.Dir))}
+
+	// You can register the shutdown handlers at any order, but do it before starting the app
+	app.RegisterShutdownHandler(
+		&app.ShutdownHandler{
+			Name:     "http_server",
+			Priority: app.ShutdownPriority(100),
+			Handler:  httpServer.Shutdown,
+			Policy:   app.ErrorPolicyAbort,
+		},
+	)
+
+	// Run the main loop until it finishes or receives termination signal
+	// On this point the readiness probe starts returning success.
+	app.RunAndWait(func() error {
+		return httpServer.ListenAndServe()
+	})
+}

--- a/app/probe.go
+++ b/app/probe.go
@@ -1,0 +1,102 @@
+package app
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/arquivei/foundationkit/errors"
+)
+
+// Probe stores the state of a probe (`true` or `false` for ok and not ok respectively).
+type Probe struct {
+	ok *bool
+}
+
+// Set changes the state of a probe. Use `true` for ok and `false` for not ok.
+func (p *Probe) Set(ok bool) {
+	*p.ok = ok
+}
+
+// SetOk sets the probe as ok. Same as `Set(true)`.
+func (p *Probe) SetOk() {
+	*p.ok = true
+}
+
+// SetNotOk sets the probe as not ok. Same as `Set(false)`.
+func (p *Probe) SetNotOk() {
+	*p.ok = false
+}
+
+// IsOk returns the state of the probe  (`true` or `false` for ok and not ok respectively).
+func (p *Probe) IsOk() bool {
+	return *p.ok
+}
+
+// ProbeGroup aggregates and manages probes.
+type ProbeGroup struct {
+	lock   *sync.RWMutex
+	probes map[string]*bool
+}
+
+// NewProbeGroup returns a new ProbeGroup.
+func NewProbeGroup() ProbeGroup {
+	return ProbeGroup{
+		lock:   &sync.RWMutex{},
+		probes: make(map[string]*bool),
+	}
+}
+
+// NewProbe returns a new Probe with the given name.
+func (m *ProbeGroup) NewProbe(name string, ok bool) (Probe, error) {
+	if _, ok := m.probes[name]; ok {
+		return Probe{}, errors.Errorf("probe '%s' already registered", name)
+	}
+
+	if err := m.checkName(name); err != nil {
+		return Probe{}, err
+	}
+
+	s := ok
+	m.probes[name] = &s
+	return Probe{&s}, nil
+}
+
+// MustNewProbe returns a new Probe with the given name and panics in case of error.
+func (m *ProbeGroup) MustNewProbe(name string, ok bool) Probe {
+	p, err := m.NewProbe(name, ok)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+var reIsValidProbeName = regexp.MustCompile("[a-zA-Z0-9_/-]{3,}")
+
+func (ProbeGroup) checkName(name string) error {
+	if !reIsValidProbeName.MatchString(name) {
+		return errors.Errorf("name '%s' doesn't conform to '[a-zA-Z0-9_-]{3,}'", name)
+	}
+	return nil
+}
+
+// CheckProbes range through the probes and returns the state of the group.
+// If any probe is not ok (false) the group state is not ok (false).
+// If the group is not ok, it's also returned the cause in the second return parameter.
+// If more than one probe is not ok, the causes are concatenated by a comma.
+func (m *ProbeGroup) CheckProbes() (bool, string) {
+	ok := true
+	cause := strings.Builder{}
+
+	for name, probeOk := range m.probes {
+		if !*probeOk {
+			ok = false
+			if cause.Len() > 0 {
+				cause.WriteString(",")
+			}
+			cause.WriteString(name)
+		}
+	}
+
+	return ok, cause.String()
+}

--- a/gokitmiddlewares/stalemiddleware/config.go
+++ b/gokitmiddlewares/stalemiddleware/config.go
@@ -3,18 +3,29 @@ package stalemiddleware
 import (
 	"time"
 
+	"github.com/arquivei/foundationkit/app"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
+// Config TODO
 type Config struct {
 	Logger                 *zerolog.Logger
 	MaxTimeBetweenRequests time.Duration
 	StartCheckAfter        time.Duration
+	HealthinessPobe        app.Probe
 }
 
-var DefaultConfig = Config{
-	MaxTimeBetweenRequests: time.Minute,
-	Logger:                 &log.Logger,
-	StartCheckAfter:        10 * time.Second,
+// NewDefaultConfig TODO
+func NewDefaultConfig(pg *app.ProbeGroup) Config {
+	probe, err := pg.NewProbe("fkit/stale", true)
+	if err != nil {
+		panic(err)
+	}
+	return Config{
+		MaxTimeBetweenRequests: time.Minute,
+		Logger:                 &log.Logger,
+		StartCheckAfter:        10 * time.Second,
+		HealthinessPobe:        probe,
+	}
 }

--- a/gokitmiddlewares/stalemiddleware/config.go
+++ b/gokitmiddlewares/stalemiddleware/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Config TODO
+// Config is a struct used to configure a new stale middleware.
 type Config struct {
 	Logger                 *zerolog.Logger
 	MaxTimeBetweenRequests time.Duration
@@ -16,7 +16,7 @@ type Config struct {
 	HealthinessPobe        app.Probe
 }
 
-// NewDefaultConfig TODO
+// NewDefaultConfig returns a new `Config` with all values filled with a sane default.
 func NewDefaultConfig(pg *app.ProbeGroup) Config {
 	probe, err := pg.NewProbe("fkit/stale", true)
 	if err != nil {


### PR DESCRIPTION
Problem: The way probes were implemented was too simple, being only an
boolean variable for each probe. We couldn't manage the state of the app
from multiple places, like have a middleware to control readiness by
error count and another middleware that controls it by average latency.

Solution: The probe was changed to be a group of probes and it's final
state is determined by the state of each probe. The probes are
independent and if the group is not ok, all failed probes are returned
in the cause return parameter.

The stale middleware was altered to make use of this new feature.

The app and default app had to be refactored to allow for creating an
app before applying the middlewares. This also allows for a better
control flow in the startup process. Now the app can be created early
and shutdown handlers and probes may be registered before calling the
main loop.

Unfortunately this is a breaking change and applications will have to be
refactored to be able to take advantages oh this new and better
control-flow.

Links:

 - #68