### PR TITLE
Adds custom logging by duck typing

### DIFF
--- a/gokitmiddlewares/loggingmiddleware/customlogging.go
+++ b/gokitmiddlewares/loggingmiddleware/customlogging.go
@@ -1,0 +1,27 @@
+package loggingmiddleware
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+// LoggableEndpointRequest, if implemented, by the endpoint request type, will
+// be used to enrich the log INSTEAD of the middleware config.
+type LoggableEndpointRequest interface {
+	// EnrichLog enriches the current log context @zctx with the request data.
+	EnrichLog(
+		ctx context.Context,
+		zctx zerolog.Context,
+	) (context.Context, zerolog.Context)
+}
+
+// LoggableEndpointResponse, if implemented, by the endpoint response type, will
+// be used to enrich the log INSTEAD of the middleware config.
+type LoggableEndpointResponse interface {
+	// EnrichLog enriches the current log context @zctx with the response data.
+	EnrichLog(
+		ctx context.Context,
+		zctx zerolog.Context,
+	) zerolog.Context
+}

--- a/gokitmiddlewares/loggingmiddleware/customlogging.go
+++ b/gokitmiddlewares/loggingmiddleware/customlogging.go
@@ -7,7 +7,7 @@ import (
 )
 
 // LoggableEndpointRequest, if implemented, by the endpoint request type, will
-// be used to enrich the log INSTEAD of the middleware config.
+// be used to enrich the log along with the EnrichLogWithRequest config.
 type LoggableEndpointRequest interface {
 	// EnrichLog enriches the current log context @zctx with the request data.
 	EnrichLog(
@@ -17,7 +17,7 @@ type LoggableEndpointRequest interface {
 }
 
 // LoggableEndpointResponse, if implemented, by the endpoint response type, will
-// be used to enrich the log INSTEAD of the middleware config.
+// be used to enrich the log along with the EnrichLogWithResponse config.
 type LoggableEndpointResponse interface {
 	// EnrichLog enriches the current log context @zctx with the response data.
 	EnrichLog(

--- a/gokitmiddlewares/loggingmiddleware/middleware.go
+++ b/gokitmiddlewares/loggingmiddleware/middleware.go
@@ -98,7 +98,8 @@ func doCustomEnrichRequest(
 			ctx, zctx = typedReq.EnrichLog(ctx, zctx)
 			return zctx
 		})
-	} else if config.EnrichLogWithRequest != nil {
+	}
+	if config.EnrichLogWithRequest != nil {
 		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
 			ctx, zctx = config.EnrichLogWithRequest(ctx, zctx, request)
 			return zctx
@@ -119,7 +120,8 @@ func doCustomEnrichResponse(
 			zctx = typedReq.EnrichLog(ctx, zctx)
 			return zctx
 		})
-	} else if config.EnrichLogWithResponse != nil {
+	}
+	if config.EnrichLogWithResponse != nil {
 		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
 			zctx = config.EnrichLogWithResponse(ctx, zctx, response, err)
 			return zctx

--- a/gokitmiddlewares/loggingmiddleware/middleware.go
+++ b/gokitmiddlewares/loggingmiddleware/middleware.go
@@ -33,9 +33,6 @@ func New(c Config) (endpoint.Middleware, error) {
 		return nil, errors.New("logger is nil")
 	}
 
-	shouldEnrichLogWithRequest := c.EnrichLogWithRequest != nil
-	shouldEnrichLogWithResponse := c.EnrichLogWithResponse != nil
-
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		log.Debug().Str("config", logutil.Flatten(c)).Msg("New logging endpoint middleware")
 
@@ -45,13 +42,7 @@ func New(c Config) (endpoint.Middleware, error) {
 			l, ctx := initLoggerContext(ctx, *c.Logger)
 
 			enrichLoggerContext(ctx, l, c, req)
-
-			if shouldEnrichLogWithRequest {
-				l.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
-					ctx, zctx = c.EnrichLogWithRequest(ctx, zctx, req)
-					return zctx
-				})
-			}
+			ctx = doCustomEnrichRequest(ctx, c, l, req)
 
 			defer func() {
 				var r interface{}
@@ -62,12 +53,7 @@ func New(c Config) (endpoint.Middleware, error) {
 						Msg("Logging endpoint middleware is handling an uncaught a panic. Please fix it!")
 				}
 				enrichLoggerAfterResponse(l, c, begin, resp)
-
-				if shouldEnrichLogWithResponse {
-					l.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
-						return c.EnrichLogWithResponse(ctx, zctx, resp, err)
-					})
-				}
+				doCustomEnrichResponse(ctx, c, l, resp, err)
 
 				doLogging(l, c, err)
 				if r != nil {
@@ -99,4 +85,44 @@ func toString(i interface{}, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+func doCustomEnrichRequest(
+	ctx context.Context,
+	config Config,
+	logger *zerolog.Logger,
+	request interface{},
+) context.Context {
+	if typedReq, ok := request.(LoggableEndpointRequest); ok {
+		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+			ctx, zctx = typedReq.EnrichLog(ctx, zctx)
+			return zctx
+		})
+	} else if config.EnrichLogWithRequest != nil {
+		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+			ctx, zctx = config.EnrichLogWithRequest(ctx, zctx, request)
+			return zctx
+		})
+	}
+	return ctx
+}
+
+func doCustomEnrichResponse(
+	ctx context.Context,
+	config Config,
+	logger *zerolog.Logger,
+	response interface{},
+	err error,
+) {
+	if typedReq, ok := response.(LoggableEndpointResponse); ok {
+		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+			zctx = typedReq.EnrichLog(ctx, zctx)
+			return zctx
+		})
+	} else if config.EnrichLogWithResponse != nil {
+		logger.UpdateContext(func(zctx zerolog.Context) zerolog.Context {
+			zctx = config.EnrichLogWithResponse(ctx, zctx, response, err)
+			return zctx
+		})
+	}
 }


### PR DESCRIPTION
Currently, the way to customize the log with request/response data is to set
up a function in the config that does that.

Besides the configuration overhead, this approach makes it hard to make pre-
build resources, where minimal configuration is needed.