### PR TITLE
Add check for NFF access key

### DIFF
--- a/sefaz/accesskey/errors.go
+++ b/sefaz/accesskey/errors.go
@@ -25,6 +25,15 @@ var (
 	// ErrCodeInvalidDigit is an error code used to imply that an access has a verification digit mismatch
 	ErrCodeInvalidDigit = errors.Code("INVALID_DIGIT")
 
+	// ErrCodeInvalidSerieForNFF
+	ErrCodeInvalidSerieForNFF = errors.Code("INVALID_SERIE_FOR_NFF")
+	// ErrCodeInvalidCodigoForNFF
+	ErrCodeInvalidNumeroForNFF = errors.Code("INVALID_NUMERO_FOR_NFF")
+	// ErrCodeInvalidCNPJForNFF
+	ErrCodeInvalidCNPJForNFF = errors.Code("INVALID_CNPJ_FOR_NFF")
+	// ErrCodeInvalidCPFForNFF
+	ErrCodeInvalidCPFForNFF = errors.Code("INVALID_CPF_FOR_NFF")
+
 	// ErrEmptyAccessKey is returned when the provided access key is an empty string
 	ErrEmptyAccessKey = errors.New("access key is empty")
 	// ErrInvalidLength the access key does not contains 44 digits
@@ -43,4 +52,9 @@ var (
 	ErrInvalidModel = errors.New("access key has invalid model")
 	// ErrInvalidDigit verification digit mismatch
 	ErrInvalidDigit = errors.New("access key has invalid validation digit")
+
+	// ErrInvalidSerieForNFF
+	ErrInvalidSerieForNFF = errors.New("access key invalid serie for NFF")
+	// ErrInvalidCodigoForNFF
+	ErrInvalidNumeroForNFF = errors.New("access key invalid numero for NFF")
 )

--- a/sefaz/accesskey/validation.go
+++ b/sefaz/accesskey/validation.go
@@ -18,8 +18,8 @@ func Check(accessKey AccessKey) error {
 	return nil
 }
 
-// CheckNFF checks if an access key is valid also considering NFF rules. It returns an error with an specific code based on
-// the validation proble
+// CheckNFF checks if an access key is valid with more restrictive rules also considering NFF.
+// It returns an error with an specific code based on the validation proble
 func CheckNFF(accessKey AccessKey) error {
 	const op errors.Op = "accesskey.CheckWithNFF"
 
@@ -95,7 +95,7 @@ func (v *validator) Check(accessKey AccessKey) error {
 
 func isNFF(accessKey AccessKey) bool {
 	/*model = 55 && tpEmis = 3 && AAMM more recent than April 2021*/
-	if accessKey[20:22] == "55" && accessKey[34:35] == "3" && accessKey[2:6] >= "2104" {
+	if accessKey[20:22] == "55" && accessKey[34] == '3' && accessKey[2:6] >= "2104" {
 		return true
 	}
 	return false
@@ -202,7 +202,7 @@ func isValidMonth(month string) bool {
 	}
 }
 
-func isValidDate(month string, day string) bool {
+func isValidMonthDay(month string, day string) bool {
 	if len(month) != 2 {
 		return false
 	}
@@ -211,7 +211,7 @@ func isValidDate(month string, day string) bool {
 		return false
 	}
 
-	if month == "00" {
+	if day == "00" {
 		return false
 	}
 
@@ -228,6 +228,8 @@ func isValidDate(month string, day string) bool {
 		if day > "29" {
 			return false
 		}
+	default:
+		return false
 	}
 
 	return true
@@ -294,7 +296,7 @@ func isValidSerieForNFF(serie string) bool {
 }
 
 func isValidNumeroForNFF(numero string) bool {
-	if !isValidDate(numero[0:2], numero[2:4]) {
+	if !isValidMonthDay(numero[0:2], numero[2:4]) {
 		return false
 	}
 	if numero[4] != '1' && numero[4] != '2' {

--- a/sefaz/accesskey/validation.go
+++ b/sefaz/accesskey/validation.go
@@ -18,7 +18,27 @@ func Check(accessKey AccessKey) error {
 	return nil
 }
 
-// validate execute all sub-routines necessary to perform a full accesskey validation
+// CheckNFF checks if an access key is valid also considering NFF rules. It returns an error with an specific code based on
+// the validation proble
+func CheckNFF(accessKey AccessKey) error {
+	const op errors.Op = "accesskey.CheckWithNFF"
+
+	err := validate(accessKey)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	if isNFF(accessKey) {
+		err := validateNFF(accessKey)
+		if err != nil {
+			return errors.E(op, err)
+		}
+	}
+
+	return nil
+}
+
+// validate execute all sub-routines necessary to perform a full accesskey validation for regular NFes
 func validate(accessKey AccessKey) error {
 	const op errors.Op = "validate"
 
@@ -71,6 +91,41 @@ func (v *validator) Check(accessKey AccessKey) error {
 	}
 
 	return errors.E(op, err)
+}
+
+func isNFF(accessKey AccessKey) bool {
+	/*model = 55 && tpEmis = 3 && AAMM more recent than April 2021*/
+	if accessKey[20:22] == "55" && accessKey[34:35] == "3" && accessKey[2:6] >= "2104" {
+		return true
+	}
+	return false
+}
+
+// validate execute all sub-routines necessary to perform a full accesskey validation for NFF
+func validateNFF(accessKey AccessKey) error {
+	const op errors.Op = "validateNFF"
+
+	if !isValidSerieForNFF(accessKey[22:25].String()) {
+		return errors.E(op, ErrInvalidSerieForNFF, ErrCodeInvalidSerieForNFF)
+	}
+
+	if !isValidNumeroForNFF(accessKey[25:34].String()) {
+		return errors.E(op, ErrInvalidNumeroForNFF, ErrCodeInvalidNumeroForNFF)
+	}
+
+	if accessKey[29] == '1' {
+		err := stakeholder.CheckCNPJ(accessKey[6:20].String())
+		if err != nil {
+			return errors.E(op, err, ErrCodeInvalidCNPJForNFF)
+		}
+	} else if accessKey[29] == '2' {
+		err := stakeholder.CheckCPF(accessKey[6:20].String())
+		if err != nil {
+			return errors.E(op, err, ErrCodeInvalidCPFForNFF)
+		}
+	}
+
+	return nil
 }
 
 func isDigitOnly(accesskey AccessKey) bool {
@@ -147,6 +202,37 @@ func isValidMonth(month string) bool {
 	}
 }
 
+func isValidDate(month string, day string) bool {
+	if len(month) != 2 {
+		return false
+	}
+
+	if len(day) != 2 {
+		return false
+	}
+
+	if month == "00" {
+		return false
+	}
+
+	switch month {
+	case "01", "03", "05", "07", "08", "10", "12":
+		if day > "31" {
+			return false
+		}
+	case "04", "06", "09", "11":
+		if day > "30" {
+			return false
+		}
+	case "02":
+		if day > "29" {
+			return false
+		}
+	}
+
+	return true
+}
+
 func isValidModel(model string) bool {
 	return model == "01" || model == "1A" ||
 		model == "02" || model == "04" ||
@@ -201,4 +287,19 @@ func isValidCPFCNPJ(cpfcnpj string) bool {
 	}
 
 	return stakeholder.CheckCPF(cpfcnpj[3:14]) == nil
+}
+
+func isValidSerieForNFF(serie string) bool {
+	return serie[0] != '0'
+}
+
+func isValidNumeroForNFF(numero string) bool {
+	if !isValidDate(numero[0:2], numero[2:4]) {
+		return false
+	}
+	if numero[4] != '1' && numero[4] != '2' {
+		return false
+	}
+
+	return true
 }

--- a/sefaz/accesskey/validation_test.go
+++ b/sefaz/accesskey/validation_test.go
@@ -13,9 +13,15 @@ func TestCheck_ShouldReturnNilForValidAccessKeys(t *testing.T) {
 	err := Check(key)
 
 	assert.Nil(t, err)
+
+	key = AccessKey("35210501180169000133551210501100013022024517")
+
+	err = CheckNFF(key)
+
+	assert.Nil(t, err)
 }
 
-func TestCheck_ShouldReturnValidationCodes(t *testing.T) {
+func TestCheck_ShouldReturnValidationCodesForNFe(t *testing.T) {
 	tests := map[string]struct {
 		key          AccessKey
 		expectedCode errors.Code
@@ -60,6 +66,79 @@ func TestCheck_ShouldReturnValidationCodes(t *testing.T) {
 
 	for testName, testCase := range tests {
 		err := Check(testCase.key)
+		code := errors.GetCode(err)
+
+		if code != testCase.expectedCode {
+			t.Errorf("Wrong validation for key '%s', expected an '%s' error", testCase.key, testName)
+		}
+	}
+}
+
+func TestCheck_ShouldReturnValidationCodesForNFF(t *testing.T) {
+	tests := map[string]struct {
+		key          AccessKey
+		expectedCode errors.Code
+	}{
+		"Empty access key": {
+			key:          "",
+			expectedCode: ErrCodeEmptyAccessKey,
+		},
+		"Invalid length": {
+			key:          "351909011801690001335500100002",
+			expectedCode: ErrCodeInvalidLength,
+		},
+		"Non numeric key": {
+			key:          "3519O901180169O00133550010000297701022024512",
+			expectedCode: ErrCodeInvalidCharacter,
+		},
+		"Invalid UF": {
+			key:          "95190901180169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidUF,
+		},
+		"Invalid month": {
+			key:          "35194201180169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidMonth,
+		},
+		"Invalid CPF": {
+			key:          "42160300005475399984558910004353741212308338",
+			expectedCode: ErrCodeInvalidCPFCNPJ,
+		},
+		"Invalid CNPJ": {
+			key:          "35190901429169000133550010000297701022024512",
+			expectedCode: ErrCodeInvalidCPFCNPJ,
+		},
+		"Invalid model": {
+			key:          "35190901180169000133420010000297701022024512",
+			expectedCode: ErrCodeInvalidModel,
+		},
+		"Invalid digit": {
+			key:          "35190901180169000133550010000297701022024513",
+			expectedCode: ErrCodeInvalidDigit,
+		},
+		"Invalid NFF - Invalid serie": {
+			key:          "35210501180169000133550210501100013022024512",
+			expectedCode: ErrCodeInvalidSerieForNFF,
+		},
+		"Invalid NFF - Invalid numero: emission date": {
+			key:          "35210501180169000133551210532100013022024515",
+			expectedCode: ErrCodeInvalidNumeroForNFF,
+		},
+		"Invalid NFF - Invalid numero: emitter cpf or cnpj": {
+			key:          "35210501180169000133551210501300013022024514",
+			expectedCode: ErrCodeInvalidNumeroForNFF,
+		},
+		"Invalid NFF - Invalid numero: invalid cnpj": {
+			key:          "35210500091387151630551210501100013022024511",
+			expectedCode: ErrCodeInvalidCNPJForNFF,
+		},
+		"Invalid NFF - Invalid numero: invalid cpf": {
+			key:          "35210501180169000133551210501200013022024510",
+			expectedCode: ErrCodeInvalidCPFForNFF,
+		},
+	}
+
+	for testName, testCase := range tests {
+		err := CheckNFF(testCase.key)
 		code := errors.GetCode(err)
 
 		if code != testCase.expectedCode {


### PR DESCRIPTION
Problem:

- There are new rules for NFe access key validation under NFF regime

Solution:

- Add these new validations on a new check method called CheckNFF on the
  accesskey package