### PR TITLE
Add avroutil and schemaregistry

### DIFF
--- a/avroutil/decoder.go
+++ b/avroutil/decoder.go
@@ -1,0 +1,84 @@
+package avroutil
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+	"github.com/arquivei/foundationkit/trace"
+
+	"github.com/hamba/avro"
+)
+
+// Decoder is able to transform avro's wire format data into golang's
+// concrete types
+type Decoder interface {
+	// Decode decodes @data, in the wire format, into @output.
+	Decode(ctx context.Context, data []byte, output interface{}) error
+}
+
+type implDecoder struct {
+	schemaRepository schemaregistry.Repository
+}
+
+// NewDecoder returns a concrete implementation of Decoder, that
+// fetches schemas in schema registry
+func NewDecoder(schemaRepository schemaregistry.Repository) Decoder {
+	return &implDecoder{
+		schemaRepository: schemaRepository,
+	}
+}
+
+func (i *implDecoder) Decode(ctx context.Context, data []byte, output interface{}) error {
+	const op = errors.Op("avroutil.implDecoder.Decode")
+	ctx, span := trace.StartSpan(ctx, "AvroDecode")
+	defer span.End(nil)
+
+	schemaID, data, err := SplitAvroWireFormatMessage(data)
+	if err != nil {
+		return errors.E(op, err, errors.SeverityInput)
+	}
+
+	schema, err := i.schemaRepository.GetSchemaByID(ctx, schemaID)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	err = avro.Unmarshal(schema, data, output)
+	return errors.E(op, err, errors.SeverityInput)
+}
+
+// DecodeWireFormatMessage decodes any @msg data encoded with the wire format
+// into the @output variable. The @output parameter must be defined as specified by the
+// library: github.com/hamba/avro
+// Deprecated: Use avroutil.Decoder instead
+func DecodeWireFormatMessage(
+	ctx context.Context,
+	msg []byte,
+	schemaRegistry schemaregistry.Repository,
+	output interface{},
+) error {
+	const op = errors.Op("avroutil.DecodeWireFormatMessage")
+	err := NewDecoder(schemaRegistry).Decode(ctx, msg, output)
+	return errors.E(op, err)
+}
+
+// SplitAvroWireFormatMessage extracts the schema ID and the data from a
+// message written with the wire format.
+// The header is a 5-byte slice, where the first byte is equal to x00, and
+// the last four represent the ID in a 32-bit big endian integer encoding.
+// Deprecated: This is a low level implementation detail of avro decoding. Use
+// the high-level avroutil.Decoder instead
+func SplitAvroWireFormatMessage(msg []byte) (schemaregistry.ID, []byte, error) {
+	const op = errors.Op("avroutil.SplitAvroWireFormatMessage")
+	if len(msg) < 5 {
+		return 0, nil, errors.E(op, "invalid message length")
+	}
+	if msg[0] != 0x00 {
+		return 0, nil, errors.E(op, "invalid magic byte")
+	}
+	schemaID := schemaregistry.ID(binary.BigEndian.Uint32(msg[1:5]))
+	data := msg[5:]
+	return schemaID, data, nil
+}

--- a/avroutil/decoder.go
+++ b/avroutil/decoder.go
@@ -30,7 +30,11 @@ func NewDecoder(schemaRepository schemaregistry.Repository) Decoder {
 	}
 }
 
-func (i *implDecoder) Decode(ctx context.Context, data []byte, output interface{}) error {
+func (i *implDecoder) Decode(
+	ctx context.Context,
+	data []byte,
+	output interface{},
+) error {
 	const op = errors.Op("avroutil.implDecoder.Decode")
 	ctx, span := trace.StartSpan(ctx, "AvroDecode")
 	defer span.End(nil)
@@ -47,21 +51,6 @@ func (i *implDecoder) Decode(ctx context.Context, data []byte, output interface{
 
 	err = avro.Unmarshal(schema, data, output)
 	return errors.E(op, err, errors.SeverityInput)
-}
-
-// DecodeWireFormatMessage decodes any @msg data encoded with the wire format
-// into the @output variable. The @output parameter must be defined as specified by the
-// library: github.com/hamba/avro
-// Deprecated: Use avroutil.Decoder instead
-func DecodeWireFormatMessage(
-	ctx context.Context,
-	msg []byte,
-	schemaRegistry schemaregistry.Repository,
-	output interface{},
-) error {
-	const op = errors.Op("avroutil.DecodeWireFormatMessage")
-	err := NewDecoder(schemaRegistry).Decode(ctx, msg, output)
-	return errors.E(op, err)
 }
 
 // SplitAvroWireFormatMessage extracts the schema ID and the data from a

--- a/avroutil/decoder_test.go
+++ b/avroutil/decoder_test.go
@@ -1,0 +1,126 @@
+package avroutil
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+	"github.com/arquivei/foundationkit/schemaregistry/implschemaregistry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tagsSchemaID schemaregistry.ID = 1
+)
+
+var (
+	tagsSchemaStr = string(loadFile("schemas/Tags.avsc"))
+)
+
+type tagsType struct {
+	Tags []string `avro:"Tags"`
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          []byte
+		expectedResult tagsType
+		expectedError  string
+	}{
+		{
+			name:  "Success",
+			input: []byte{0, 0, 0, 0, 1, 5, 12, 2, 97, 2, 98, 2, 99, 0},
+			expectedResult: tagsType{
+				Tags: []string{"a", "b", "c"},
+			},
+			expectedError: "",
+		},
+		{
+			name:          "Error - Failed to split",
+			input:         []byte{0},
+			expectedError: "invalid message length",
+		},
+		{
+			name:          "Error - Schema ID not found",
+			input:         []byte{0, 0, 0, 0, 99, 5, 12, 2, 97, 2, 98, 2, 99, 0},
+			expectedError: "could not find schema [id=99]",
+		},
+	}
+	schemaRegistry := implschemaregistry.MustNewMock(map[schemaregistry.ID]string{
+		tagsSchemaID: tagsSchemaStr,
+	})
+	decoder := NewDecoder(schemaRegistry)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tags tagsType
+			err := decoder.Decode(context.Background(), test.input, &tags)
+			if test.expectedError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedResult, tags)
+			} else {
+				assert.EqualError(t, errors.GetRootErrorWithKV(err), test.expectedError)
+			}
+		})
+	}
+}
+
+func loadFile(name string) []byte {
+	content, err := ioutil.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		panic(err)
+	}
+	return content
+}
+
+func TestSplitAvroWireFormatMessage(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         []byte
+		expectedID   schemaregistry.ID
+		expectedData []byte
+	}{
+		{
+			"zeros",
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			schemaregistry.ID(0),
+			[]byte{0x00},
+		},
+		{
+			"one",
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x01, 0xFF},
+			schemaregistry.ID(1),
+			[]byte{0xFF},
+		},
+		{
+			"bignumber",
+			[]byte{0x00, 0x0F, 0x00, 0x00, 0x00, 0xAB},
+			schemaregistry.ID(0x0F000000),
+			[]byte{0xAB},
+		},
+		{
+			"empty",
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x01},
+			schemaregistry.ID(0x01),
+			[]byte{},
+		},
+	}
+	for _, test := range tests {
+		id, data, err := SplitAvroWireFormatMessage(test.data)
+		assert.NoError(t, err, test.name)
+		assert.Equal(t, test.expectedID, id, test.name)
+		assert.Equal(t, test.expectedData, data, test.name)
+	}
+}
+
+func TestSplitAvroWireFormatMessageError(t *testing.T) {
+	_, _, err := SplitAvroWireFormatMessage([]byte{0x00, 0x00, 0x00, 0x00})
+	assert.Error(t, err)
+
+	_, _, err = SplitAvroWireFormatMessage([]byte{0x01, 0x00, 0x00, 0x00, 0x00, 0x00})
+	assert.Error(t, err)
+}

--- a/avroutil/encoder.go
+++ b/avroutil/encoder.go
@@ -1,0 +1,91 @@
+package avroutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/hamba/avro"
+)
+
+// Encoder is able to transform golang's concrete types into avro's wire format
+type Encoder interface {
+	// Decode decodes @data, in the wire format, into @output.
+	Encode(input interface{}) ([]byte, error)
+}
+
+type implEncoder struct {
+	writerSchemaID schemaregistry.ID
+	writerSchema   avro.Schema
+}
+
+// NewEncoder returns a concrete implementation of Decoder, that
+// fetches schemas in schema registry
+// Parameters:
+// - @schemaRepository: repository for avro schemas.
+// - @writerSchemaStr: avro schema, in the avsc format, used to marshall the
+//   objects. This schema must be previusly registered in the schema registry
+//   exactly as provided.
+func NewEncoder(
+	ctx context.Context,
+	schemaRepository schemaregistry.Repository,
+	subject schemaregistry.Subject,
+	writerSchemaStr string,
+) (Encoder, error) {
+	const op = errors.Op("avroutil.NewEncoder")
+	schemaID, parsedSchema, err := schemaRepository.GetIDBySchema(
+		ctx,
+		subject,
+		writerSchemaStr,
+	)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	return &implEncoder{
+		writerSchemaID: schemaID,
+		writerSchema:   parsedSchema,
+	}, nil
+}
+
+func (e *implEncoder) Encode(input interface{}) ([]byte, error) {
+	const op = errors.Op("avroutil.implEncoder.Encode")
+
+	avroData, err := avro.Marshal(e.writerSchema, input)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	wireFormat, err := joinAvroWireFormatMessage(e.writerSchemaID, avroData)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	return wireFormat, nil
+}
+
+// joinAvroWireFormatMessage uses the schema ID and the data from a message
+// to write it as an Avro Wire Format message.
+// The header is a 5-byte slice, where the first byte is equal to x00, and
+// the last four represent the ID in a 32-bit big endian integer encoding.
+func joinAvroWireFormatMessage(schemaID schemaregistry.ID, msg []byte) ([]byte, error) {
+	const op = errors.Op("joinAvroWireFormatMessage")
+
+	buf := new(bytes.Buffer)
+
+	if err := buf.WriteByte(0x00); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	if err := binary.Write(buf, binary.BigEndian, int32(schemaID)); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	if _, err := buf.Write(msg); err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/avroutil/encoder.go
+++ b/avroutil/encoder.go
@@ -13,7 +13,7 @@ import (
 
 // Encoder is able to transform golang's concrete types into avro's wire format
 type Encoder interface {
-	// Decode decodes @data, in the wire format, into @output.
+	// Encode encodes @input in the wire format
 	Encode(input interface{}) ([]byte, error)
 }
 
@@ -70,7 +70,10 @@ func (e *implEncoder) Encode(input interface{}) ([]byte, error) {
 // to write it as an Avro Wire Format message.
 // The header is a 5-byte slice, where the first byte is equal to x00, and
 // the last four represent the ID in a 32-bit big endian integer encoding.
-func joinAvroWireFormatMessage(schemaID schemaregistry.ID, msg []byte) ([]byte, error) {
+func joinAvroWireFormatMessage(
+	schemaID schemaregistry.ID,
+	msg []byte,
+) ([]byte, error) {
 	const op = errors.Op("joinAvroWireFormatMessage")
 
 	buf := new(bytes.Buffer)

--- a/avroutil/encoder_test.go
+++ b/avroutil/encoder_test.go
@@ -1,0 +1,62 @@
+package avroutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+	"github.com/arquivei/foundationkit/schemaregistry/implschemaregistry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncoder(t *testing.T) {
+	tests := []struct {
+		name                string
+		input               tagsType
+		writerSchemaStr     string
+		schemaRepository    schemaregistry.Repository
+		expectedResult      []byte
+		expectedNewError    string
+		expectedEncodeError string
+	}{
+		{
+			name: "Success",
+			input: tagsType{
+				Tags: []string{"a", "b", "c"},
+			},
+			writerSchemaStr: tagsSchemaStr,
+			schemaRepository: implschemaregistry.MustNewMock(map[schemaregistry.ID]string{
+				tagsSchemaID: tagsSchemaStr,
+			}),
+			expectedResult: []byte{0, 0, 0, 0, 1, 5, 12, 2, 97, 2, 98, 2, 99, 0},
+		},
+		{
+			name: "Error - failed to get schema ID",
+			input: tagsType{
+				Tags: []string{"a", "b", "c"},
+			},
+			writerSchemaStr:  tagsSchemaStr,
+			schemaRepository: implschemaregistry.MustNewMock(map[schemaregistry.ID]string{}),
+			expectedNewError: "could not find schema [subject=subject]",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoder, err := NewEncoder(context.Background(), test.schemaRepository, "subject", test.writerSchemaStr)
+			if test.expectedNewError != "" {
+				assert.EqualError(t, errors.GetRootErrorWithKV(err), test.expectedNewError)
+				return
+			}
+			assert.NoError(t, err)
+			result, err := encoder.Encode(test.input)
+			if test.expectedEncodeError == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedResult, result)
+			} else {
+				assert.EqualError(t, errors.GetRootErrorWithKV(err), test.expectedEncodeError)
+			}
+		})
+	}
+}

--- a/avroutil/mock.go
+++ b/avroutil/mock.go
@@ -1,0 +1,60 @@
+package avroutil
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockDecoder is a special implementation of Decoder, useful for
+// unit testing
+type MockDecoder struct {
+	mock.Mock
+}
+
+// Decode decodes @data, in the wire format, into @output.
+func (i *MockDecoder) Decode(ctx context.Context, data []byte, output interface{}) error {
+	args := i.Called(data)
+	err := args.Error(1)
+	if err == nil {
+		i.handleOutput(args, output)
+	}
+	return err
+}
+
+func (i *MockDecoder) handleOutput(args mock.Arguments, output interface{}) {
+	isJSON := args.Bool(2)
+	if isJSON {
+		jsonMock := args.Get(0).(string)
+
+		err := json.Unmarshal([]byte(jsonMock), output)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		i.setMockToOutput(output, args.Get(0))
+	}
+}
+
+func (i *MockDecoder) setMockToOutput(output, mocked interface{}) {
+	rv1 := reflect.ValueOf(output)
+	if rv1.Kind() != reflect.Ptr || rv1.IsNil() {
+		panic("invalid output type")
+	}
+	rv2 := reflect.ValueOf(mocked)
+	rv1.Elem().Set(rv2)
+}
+
+// AddBinding mocks the decoding result of @data to the @output struct
+func (i *MockDecoder) AddBinding(data []byte, output interface{}, err error) *mock.Call {
+	return i.On("Decode", data).Return(output, err, false)
+}
+
+// AddJSONBinding mocks the decoding of @data with the JSON-encoded data in
+// @output. Use this function when the output structure is hard to define in
+// unit tests, ex: anonymous structs with lots of pointers.
+func (i *MockDecoder) AddJSONBinding(data []byte, output string, err error) *mock.Call {
+	return i.On("Decode", data).Return(output, err, true)
+}

--- a/avroutil/mock_test.go
+++ b/avroutil/mock_test.go
@@ -1,0 +1,59 @@
+package avroutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myStruct struct {
+	X int
+}
+
+func TestMockAddBinding(t *testing.T) {
+	decoder := new(MockDecoder)
+	decoder.AddBinding([]byte("int"), 1, nil)
+	decoder.AddBinding([]byte("string"), "str", nil)
+	decoder.AddBinding([]byte("struct"), myStruct{X: 1}, nil)
+	decoder.AddBinding([]byte("error"), nil, errors.New("err"))
+	var outputInt int
+	var outputString string
+	var outputStruct myStruct
+
+	_ = decoder.Decode(context.Background(), []byte("int"), &outputInt)
+	_ = decoder.Decode(context.Background(), []byte("string"), &outputString)
+	_ = decoder.Decode(context.Background(), []byte("struct"), &outputStruct)
+
+	assert.Equal(t, 1, outputInt)
+	assert.Equal(t, "str", outputString)
+	assert.Equal(t, myStruct{X: 1}, outputStruct)
+
+	assert.Error(t, decoder.Decode(context.Background(), []byte("error"), &outputInt))
+
+	decoder.AssertExpectations(t)
+}
+
+func TestMockAddJSON(t *testing.T) {
+	decoder := new(MockDecoder)
+	decoder.AddJSONBinding([]byte("int"), "1", nil)
+	decoder.AddJSONBinding([]byte("string"), "\"str\"", nil)
+	decoder.AddJSONBinding([]byte("struct"), "{\"X\": 1}", nil)
+	decoder.AddJSONBinding([]byte("error"), "", errors.New("err"))
+	var outputInt int
+	var outputString string
+	var outputStruct myStruct
+
+	_ = decoder.Decode(context.Background(), []byte("int"), &outputInt)
+	_ = decoder.Decode(context.Background(), []byte("string"), &outputString)
+	_ = decoder.Decode(context.Background(), []byte("struct"), &outputStruct)
+
+	assert.Equal(t, 1, outputInt)
+	assert.Equal(t, "str", outputString)
+	assert.Equal(t, myStruct{X: 1}, outputStruct)
+
+	assert.Error(t, decoder.Decode(context.Background(), []byte("error"), &outputInt))
+
+	decoder.AssertExpectations(t)
+}

--- a/avroutil/testdata/schemas/Tags.avsc
+++ b/avroutil/testdata/schemas/Tags.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "Tags",
+  "namespace" : "com.arquivei.saas",
+  "fields" : [ {
+    "name" : "Tags",
+    "type" : {
+      "type" : "array",
+      "items" : "string"
+    },
+    "doc" : "Lista de tags"
+  } ]
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-kit/kit v0.11.0
 	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/hamba/avro v1.5.6
 	github.com/oklog/ulid v1.3.1
 	github.com/omeid/uconfig v1.2.0
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,9 @@ github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -221,6 +222,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hamba/avro v1.5.6 h1:/UBljlJ9hLjkcY7PhpI/bFYb4RMEXHEwHr17gAm/+l8=
+github.com/hamba/avro v1.5.6/go.mod h1:3vNT0RLXXpFm2Tb/5KC71ZRJlOroggq1Rcitb6k4Fr8=
 github.com/hashicorp/consul/api v1.8.1/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+XbolEz1952UB+mk=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -254,6 +257,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
@@ -292,8 +296,10 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/schemaregistry/implschemaregistry/cache.go
+++ b/schemaregistry/implschemaregistry/cache.go
@@ -1,0 +1,66 @@
+package implschemaregistry
+
+import (
+	"context"
+	"sync"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/hamba/avro"
+)
+
+type cacheRepository struct {
+	next  schemaregistry.Repository
+	cache map[schemaregistry.ID]avro.Schema
+	lock  sync.RWMutex
+}
+
+// WrapWithCache wraps @next with a cache layer that stores the result indefinitely
+func WrapWithCache(next schemaregistry.Repository) schemaregistry.Repository {
+	return &cacheRepository{
+		next:  next,
+		lock:  sync.RWMutex{},
+		cache: map[schemaregistry.ID]avro.Schema{},
+	}
+}
+
+func (r *cacheRepository) GetSchemaByID(ctx context.Context, id schemaregistry.ID) (avro.Schema, error) {
+	const op = errors.Op("implschemaregistry.cacheRepository.GetSchemaById")
+
+	if schema, ok := r.tryGetSchemaFromCache(id); ok {
+		return schema, nil
+	}
+
+	schema, err := r.next.GetSchemaByID(ctx, id)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
+	r.storeResult(id, schema)
+
+	return schema, nil
+}
+
+func (r *cacheRepository) tryGetSchemaFromCache(id schemaregistry.ID) (avro.Schema, bool) {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+
+	schema, ok := r.cache[id]
+	return schema, ok
+}
+
+func (r *cacheRepository) storeResult(id schemaregistry.ID, schema avro.Schema) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.cache[id] = schema
+}
+
+func (r *cacheRepository) GetIDBySchema(
+	ctx context.Context,
+	subject schemaregistry.Subject,
+	schema string,
+) (schemaregistry.ID, avro.Schema, error) {
+	return r.next.GetIDBySchema(ctx, subject, schema)
+}

--- a/schemaregistry/implschemaregistry/cache_test.go
+++ b/schemaregistry/implschemaregistry/cache_test.go
@@ -1,0 +1,100 @@
+package implschemaregistry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/hamba/avro"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCacheGetSchemaByID(t *testing.T) {
+	mock := new(mockTestRepository)
+	mock.On("GetSchemaByID", schemaregistry.ID(10)).
+		Return(tagsSchema, nil).
+		Once()
+	mock.On("GetSchemaByID", schemaregistry.ID(99)).
+		Return(tagsSchema, errors.New("not found")).
+		Once()
+
+	repository := WrapWithCache(mock)
+	// First time, fetch from repository
+	schema, err := repository.GetSchemaByID(context.Background(), 10)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+
+	// Second time, get from cache
+	schema, err = repository.GetSchemaByID(context.Background(), 10)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+
+	// Repository returned error
+	_, err = repository.GetSchemaByID(context.Background(), 99)
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "not found")
+}
+
+func TestCacheGetIDBySchema(t *testing.T) {
+	mock := new(mockTestRepository)
+	mock.
+		On("GetIDBySchema", schemaregistry.Subject("mysubject"), tagsSchemaStr).
+		Return(schemaregistry.ID(10), tagsSchema, nil).
+		Twice()
+	mock.
+		On("GetIDBySchema", schemaregistry.Subject("mysubject"), "wrongschema").
+		Return(schemaregistry.ID(10), tagsSchema, errors.New("not found")).
+		Once()
+
+	repository := WrapWithCache(mock)
+	// First time, fetch from repository
+	id, schema, err := repository.GetIDBySchema(
+		context.Background(),
+		schemaregistry.Subject("mysubject"),
+		tagsSchemaStr,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+	assert.Equal(t, schemaregistry.ID(10), id)
+
+	// Second time, fetch from repository. CACHE IS NOT IMPLEMENTED
+	id, schema, err = repository.GetIDBySchema(
+		context.Background(),
+		schemaregistry.Subject("mysubject"),
+		tagsSchemaStr,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+	assert.Equal(t, schemaregistry.ID(10), id)
+
+	// Repository returned error
+	_, _, err = repository.GetIDBySchema(
+		context.Background(),
+		schemaregistry.Subject("mysubject"),
+		"wrongschema",
+	)
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "not found")
+}
+
+type mockTestRepository struct {
+	mock.Mock
+}
+
+func (m *mockTestRepository) GetSchemaByID(
+	ctx context.Context,
+	id schemaregistry.ID,
+) (avro.Schema, error) {
+	args := m.Called(id)
+	return args.Get(0).(avro.Schema), args.Error(1)
+}
+func (m *mockTestRepository) GetIDBySchema(
+	ctx context.Context,
+	subject schemaregistry.Subject,
+	schema string,
+) (schemaregistry.ID, avro.Schema, error) {
+	args := m.Called(subject, schema)
+	return args.Get(0).(schemaregistry.ID),
+		args.Get(1).(avro.Schema), args.Error(2)
+}

--- a/schemaregistry/implschemaregistry/logging.go
+++ b/schemaregistry/implschemaregistry/logging.go
@@ -13,7 +13,7 @@ type loggingRepository struct {
 	next schemaregistry.Repository
 }
 
-// WrapWithLogging wraps @next with a cache layer that stores the result indefinitely
+// WrapWithLogging wraps @next with a logging layer
 func WrapWithLogging(next schemaregistry.Repository) schemaregistry.Repository {
 	return &loggingRepository{
 		next: next,

--- a/schemaregistry/implschemaregistry/logging.go
+++ b/schemaregistry/implschemaregistry/logging.go
@@ -1,0 +1,60 @@
+package implschemaregistry
+
+import (
+	"context"
+
+	"github.com/hamba/avro"
+	"github.com/rs/zerolog/log"
+
+	"github.com/arquivei/foundationkit/schemaregistry"
+)
+
+type loggingRepository struct {
+	next schemaregistry.Repository
+}
+
+// WrapWithLogging wraps @next with a cache layer that stores the result indefinitely
+func WrapWithLogging(next schemaregistry.Repository) schemaregistry.Repository {
+	return &loggingRepository{
+		next: next,
+	}
+}
+
+func (r *loggingRepository) GetSchemaByID(ctx context.Context, id schemaregistry.ID) (_ avro.Schema, err error) {
+	defer func() {
+		logger := log.Ctx(ctx)
+		if err != nil {
+			logger.Error().
+				Err(err).
+				EmbedObject(id).
+				Msg("GetSchemaByID returned an error")
+		} else {
+			logger.Debug().
+				EmbedObject(id).
+				Msg("GetSchemaByID returned successfully")
+		}
+	}()
+	return r.next.GetSchemaByID(ctx, id)
+}
+
+func (r *loggingRepository) GetIDBySchema(
+	ctx context.Context,
+	subject schemaregistry.Subject,
+	schema string,
+) (id schemaregistry.ID, _ avro.Schema, err error) {
+	defer func() {
+		logger := log.Ctx(ctx)
+		if err != nil {
+			logger.Error().
+				Err(err).
+				Str("subject", string(subject)).
+				Msg("GetIDBySchema returned an error")
+		} else {
+			logger.Debug().
+				EmbedObject(id).
+				Str("subject", string(subject)).
+				Msg("GetIDBySchema returned successfully")
+		}
+	}()
+	return r.next.GetIDBySchema(ctx, subject, schema)
+}

--- a/schemaregistry/implschemaregistry/logging_test.go
+++ b/schemaregistry/implschemaregistry/logging_test.go
@@ -1,0 +1,93 @@
+package implschemaregistry
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggingGetSchemaByID(t *testing.T) {
+	schemaregistryID := schemaregistry.ID(10)
+
+	mock := new(mockTestRepository)
+	mock.
+		On("GetSchemaByID", schemaregistryID).
+		Return(tagsSchema, nil).
+		Once()
+
+	repository := WrapWithLogging(mock)
+
+	schema, err := repository.GetSchemaByID(
+		context.Background(),
+		schemaregistryID,
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchema.String(), schema.String())
+}
+
+func TestLoggingGetSchemaByID_Error(t *testing.T) {
+	schemaregistryID := schemaregistry.ID(10)
+
+	mock := new(mockTestRepository)
+	mock.
+		On("GetSchemaByID", schemaregistryID).
+		Return(tagsSchema, errors.New("error")).
+		Once()
+
+	repository := WrapWithLogging(mock)
+
+	schema, err := repository.GetSchemaByID(
+		context.Background(),
+		schemaregistryID,
+	)
+	assert.EqualError(t, err, "error")
+	assert.Equal(t, tagsSchema.String(), schema.String())
+}
+
+func TestLoggingGetIDBySchema(t *testing.T) {
+	schemaregistrySubject := schemaregistry.Subject("mysubject")
+	schemaregistryID := schemaregistry.ID(10)
+
+	mock := new(mockTestRepository)
+	mock.
+		On("GetIDBySchema", schemaregistrySubject, tagsSchema.String()).
+		Return(schemaregistryID, tagsSchema, nil).
+		Once()
+
+	repository := WrapWithLogging(mock)
+
+	id, schema, err := repository.GetIDBySchema(
+		context.Background(),
+		schemaregistrySubject,
+		tagsSchema.String(),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchema.String(), schema.String())
+	assert.Equal(t, schemaregistryID, id)
+}
+
+func TestLoggingGetIDBySchema_Error(t *testing.T) {
+	schemaregistrySubject := schemaregistry.Subject("mysubject")
+	schemaregistryID := schemaregistry.ID(10)
+
+	mock := new(mockTestRepository)
+	mock.
+		On("GetIDBySchema", schemaregistrySubject, tagsSchema.String()).
+		Return(schemaregistryID, tagsSchema, errors.New("error")).
+		Once()
+
+	repository := WrapWithLogging(mock)
+
+	id, schema, err := repository.GetIDBySchema(
+		context.Background(),
+		schemaregistrySubject,
+		tagsSchema.String(),
+	)
+	assert.EqualError(t, err, "error")
+	assert.Equal(t, tagsSchema.String(), schema.String())
+	assert.Equal(t, schemaregistryID, id)
+}

--- a/schemaregistry/implschemaregistry/mock_repository.go
+++ b/schemaregistry/implschemaregistry/mock_repository.go
@@ -1,0 +1,75 @@
+package implschemaregistry
+
+import (
+	"context"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/hamba/avro"
+)
+
+type mockRepository struct {
+	idToSchemas  map[schemaregistry.ID]avro.Schema
+	schemasToIDs map[string]schemaregistry.ID
+}
+
+// MustNewMock creates a mock schema registry.
+func MustNewMock(schemas map[schemaregistry.ID]string) schemaregistry.Repository {
+	const op = errors.Op("implschemaregistry.MustNewMock")
+	r := mockRepository{
+		idToSchemas:  make(map[schemaregistry.ID]avro.Schema),
+		schemasToIDs: make(map[string]schemaregistry.ID),
+	}
+
+	for id, schemaStr := range schemas {
+		schema, err := avro.Parse(schemaStr)
+		if err != nil {
+			panic(errors.E(
+				op,
+				err,
+				errors.KV("schema", truncateStr(schemaStr, 50)),
+			))
+		}
+		r.idToSchemas[id] = schema
+		r.schemasToIDs[schema.String()] = id
+	}
+
+	return r
+}
+
+func (r mockRepository) GetSchemaByID(ctx context.Context, id schemaregistry.ID) (avro.Schema, error) {
+	const op = errors.Op("implschemaregistry.mockRepository.GetSchemaByID")
+
+	if schema, ok := r.idToSchemas[id]; ok {
+		return schema, nil
+	}
+
+	return nil, errors.E(op, "could not find schema", errors.KV("id", id))
+}
+
+func (r mockRepository) GetIDBySchema(
+	ctx context.Context,
+	subject schemaregistry.Subject,
+	schema string,
+) (schemaregistry.ID, avro.Schema, error) {
+	const op = errors.Op("implschemaregistry.mockRepository.GetIDBySchema")
+
+	avroSchema, err := avro.Parse(schema)
+	if err != nil {
+		return 0, nil, errors.E(op, err)
+	}
+
+	if id, ok := r.schemasToIDs[avroSchema.String()]; ok {
+		return id, avroSchema, nil
+	}
+
+	return 0, nil, errors.E(op, "could not find schema", errors.KV("subject", subject))
+}
+
+func truncateStr(str string, size int) string {
+	if len(str) > size {
+		return str[0:size]
+	}
+	return str
+}

--- a/schemaregistry/implschemaregistry/mock_repository_test.go
+++ b/schemaregistry/implschemaregistry/mock_repository_test.go
@@ -1,0 +1,47 @@
+package implschemaregistry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockRepositoryGetIDBySchema(t *testing.T) {
+	mock := MustNewMock(map[schemaregistry.ID]string{
+		1: tagsSchemaStr,
+	})
+
+	id, schema, err := mock.GetIDBySchema(context.Background(), "mysubject", tagsSchemaStr)
+	assert.NoError(t, err)
+	assert.Equal(t, schemaregistry.ID(1), id)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+
+	_, _, err = mock.GetIDBySchema(context.Background(), "mysubject", "wrongschema")
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "avro: unknown type: wrongschema")
+
+	_, _, err = mock.GetIDBySchema(context.Background(), "mysubject", `{"name":"b","type":"string"}`)
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "could not find schema [subject=mysubject]")
+}
+
+func TestMockRepositoryGetSchemaByID(t *testing.T) {
+	mock := MustNewMock(map[schemaregistry.ID]string{
+		1: tagsSchemaStr,
+	})
+
+	schema, err := mock.GetSchemaByID(context.Background(), schemaregistry.ID(1))
+	assert.NoError(t, err)
+	assert.Equal(t, tagsSchemaStr, schema.String())
+
+	_, err = mock.GetSchemaByID(context.Background(), schemaregistry.ID(2))
+	assert.EqualError(t, errors.GetRootErrorWithKV(err), "could not find schema [id=2]")
+}
+
+func TestMustNewMock_Panic(t *testing.T) {
+	assert.Panics(t, func() {
+		MustNewMock(map[schemaregistry.ID]string{1: "ops"})
+	})
+}

--- a/schemaregistry/implschemaregistry/repository.go
+++ b/schemaregistry/implschemaregistry/repository.go
@@ -1,0 +1,177 @@
+package implschemaregistry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/schemaregistry"
+	"github.com/arquivei/foundationkit/trace"
+
+	"github.com/hamba/avro"
+)
+
+type repository struct {
+	getSchemaByIDURL string
+	getIDBySchemaURL string
+}
+
+type getSchemaByIDResponse struct {
+	Schema string `json:"schema"`
+}
+
+// MustNew returns a new valid schemaregistry.Repository but panics in case on an error
+func MustNew(url string, httpClient *http.Client) schemaregistry.Repository {
+	const op = errors.Op("implschemaregistry.MustNew")
+
+	if url == "" {
+		panic(errors.E(op, "missing url"))
+	}
+
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+
+	return &repository{
+		getSchemaByIDURL: url + "schemas/ids/%d",
+		getIDBySchemaURL: url + "subjects/%s",
+	}
+}
+
+// nolint:gosec, noctx
+func (r repository) GetSchemaByID(ctx context.Context, id schemaregistry.ID) (avro.Schema, error) {
+	const op = errors.Op("implschemaregistry.repository.GetSchemaByID")
+	fullURL := fmt.Sprintf(r.getSchemaByIDURL, id)
+
+	_, span := trace.StartSpan(ctx, "GetSchemaByID")
+	defer span.End(nil)
+
+	// gosec linter is given the error "Potential HTTP request made with
+	// variable url" in this line, but the URL must be built from a config
+	httpResponse, err := http.Get(fullURL)
+	if err != nil {
+		return nil, errors.E(op, err, errors.SeverityRuntime)
+	}
+	defer httpResponse.Body.Close()
+
+	response := getSchemaByIDResponse{}
+	decoder := json.NewDecoder(httpResponse.Body)
+
+	err = decoder.Decode(&response)
+	if err != nil {
+		return nil, errors.E(op, err, errors.SeverityInput)
+	}
+	schema, err := avro.Parse(response.Schema)
+	if err != nil {
+		return nil, errors.E(
+			op,
+			err,
+			errors.SeverityInput,
+			errors.KV("schema", truncateStr(response.Schema, 50)),
+		)
+	}
+	return schema, nil
+}
+
+type getIDFromSchemaResponse struct {
+	Subject string            `json:"subject"`
+	ID      schemaregistry.ID `json:"id"`
+	Version int               `json:"version"`
+	Schema  string            `json:"schema"`
+}
+
+// GetIDBySchema returns the avro schema ID by using @subject and @schema.
+// DO REALLY NOTE that schema is not avro.Schema, but a string instad. The reason
+// is that avro.Schema.String() returns the schema in it's canonical form, which may
+// unexpectedly not be recognized by the schema registry (code 40403 schema not found)
+//
+// nolint:gosec, noctx
+func (r repository) GetIDBySchema(
+	ctx context.Context,
+	subject schemaregistry.Subject,
+	schema string,
+) (schemaregistry.ID, avro.Schema, error) {
+	const op = errors.Op("implschemaregistry.repository.GetIDBySchema")
+
+	requestBody, err := makeGetIDBySchemaRequestBody(schema)
+	if err != nil {
+		return 0, nil, errors.E(op, errors.SeverityFatal, err)
+	}
+
+	fullURL := fmt.Sprintf(r.getIDBySchemaURL, subject)
+
+	// gosec linter is given the error "Potential HTTP request made with
+	// variable url" in this line, but the URL must be built from a config
+	httpResponse, err := http.Post(
+		fullURL,
+		"application/vnd.schemaregistry+json",
+		strings.NewReader(requestBody),
+	)
+	if err != nil {
+		return 0, nil, errors.E(op, errors.SeverityRuntime, err)
+	}
+	defer httpResponse.Body.Close()
+
+	switch httpResponse.StatusCode {
+	// This switch can be improved further by reading the "error_code"
+	// field in the body, if this level of information is needed.
+	case 200:
+	case 404:
+		return 0, nil, errors.E(
+			op,
+			errors.SeverityInput,
+			"schema registry returned 404 - subject or schema not found",
+		)
+	case 500:
+		return 0, nil, errors.E(
+			op,
+			errors.SeverityRuntime,
+			"internal server error",
+		)
+	default:
+		return 0, nil, errors.E(
+			op,
+			errors.SeverityRuntime,
+			"unexpected status code returned",
+			errors.KV("statusCode", httpResponse.StatusCode),
+		)
+	}
+
+	var getResponse getIDFromSchemaResponse
+	if err = json.NewDecoder(httpResponse.Body).Decode(&getResponse); err != nil {
+		return 0, nil, errors.E(op, errors.SeverityInput, err)
+	}
+
+	returnedSchema, err := avro.Parse(getResponse.Schema)
+	if err != nil {
+		return 0, nil, errors.E(op, err)
+	}
+
+	return getResponse.ID, returnedSchema, nil
+}
+
+func makeGetIDBySchemaRequestBody(schema string) (string, error) {
+	const op = errors.Op("makeGetIDBySchemaRequestBody")
+
+	buf := new(bytes.Buffer)
+	if err := json.Compact(buf, []byte(schema)); err != nil {
+		return "", errors.E(op, errors.SeverityFatal, err)
+	}
+
+	body := struct {
+		Schema string `json:"schema"`
+	}{
+		Schema: buf.String(),
+	}
+
+	marshaledBody, err := json.Marshal(&body)
+	if err != nil {
+		return "", errors.E(op, errors.SeverityFatal, err)
+	}
+
+	return string(marshaledBody), nil
+}

--- a/schemaregistry/implschemaregistry/repository_test.go
+++ b/schemaregistry/implschemaregistry/repository_test.go
@@ -1,0 +1,205 @@
+package implschemaregistry
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/arquivei/foundationkit/schemaregistry"
+
+	"github.com/hamba/avro"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	tagsSchemaStr = `{"name":"simple","type":"record","fields":[{"name":"a","type":"long"},{"name":"b","type":"string"}]}`
+	tagsSchema    = avro.MustParse(tagsSchemaStr)
+)
+
+func TestGetSchemaByID(t *testing.T) {
+	tests := []struct {
+		name          string
+		httpResponse  map[string]interface{}
+		expectedError string
+	}{
+		{
+			name: "Success",
+			httpResponse: map[string]interface{}{
+				"schema": tagsSchemaStr,
+			},
+		},
+		{
+			name: "Error - Decode Response",
+			httpResponse: map[string]interface{}{
+				"schema": 1,
+			},
+			expectedError: "implschemaregistry.repository.GetSchemaByID: json: cannot unmarshal number into Go struct field getSchemaByIDResponse.schema of type string",
+		},
+		{
+			name: "Error - Empty Schema",
+			httpResponse: map[string]interface{}{
+				"schema": "",
+			},
+			expectedError: "implschemaregistry.repository.GetSchemaByID: avro: unknown type:  [schema=]",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "/schemas/ids/10", req.URL.String())
+				assert.Equal(t, http.MethodGet, req.Method)
+				rw.WriteHeader(200)
+				out, _ := json.Marshal(test.httpResponse)
+				_, _ = rw.Write(out)
+			}))
+			defer server.Close()
+			repository := MustNew(server.URL, nil)
+			schema, err := repository.GetSchemaByID(context.Background(), schemaregistry.ID(10))
+			if test.expectedError != "" {
+				assert.EqualError(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tagsSchemaStr, schema.String())
+			}
+		})
+	}
+}
+
+func TestGetIDBySchema(t *testing.T) {
+	tests := []struct {
+		name string
+
+		schema   string
+		schemaID schemaregistry.ID
+		subject  schemaregistry.Subject
+
+		httpResponse map[string]interface{}
+		statusCode   int
+
+		expectedError string
+	}{
+		{
+			name:     "Success - 200",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id":      schemaregistry.ID(10),
+				"subject": schemaregistry.Subject("mysubject"),
+				"version": 1,
+				"schema":  tagsSchemaStr,
+			},
+			statusCode: 200,
+		},
+		{
+			name:     "Error - 404",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id":      schemaregistry.ID(10),
+				"subject": schemaregistry.Subject("mysubject"),
+				"version": 1,
+				"schema":  tagsSchemaStr,
+			},
+			statusCode:    404,
+			expectedError: "implschemaregistry.repository.GetIDBySchema: schema registry returned 404 - subject or schema not found",
+		},
+		{
+			name:     "Error - 500",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id":      schemaregistry.ID(10),
+				"subject": schemaregistry.Subject("mysubject"),
+				"version": 1,
+				"schema":  tagsSchemaStr,
+			},
+			statusCode:    500,
+			expectedError: "implschemaregistry.repository.GetIDBySchema: internal server error",
+		},
+		{
+			name:     "Error - 666",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id":      schemaregistry.ID(10),
+				"subject": schemaregistry.Subject("mysubject"),
+				"version": 1,
+				"schema":  tagsSchemaStr,
+			},
+			statusCode:    666,
+			expectedError: "implschemaregistry.repository.GetIDBySchema: unexpected status code returned [statusCode=666]",
+		},
+		{
+			name:          "Error - Invalid Schema",
+			schema:        "",
+			expectedError: "implschemaregistry.repository.GetIDBySchema: makeGetIDBySchemaRequestBody: unexpected end of JSON input",
+		},
+		{
+			name:     "Error - Response parser",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id": "bla",
+			},
+			statusCode:    200,
+			expectedError: "implschemaregistry.repository.GetIDBySchema: json: cannot unmarshal string into Go struct field getIDFromSchemaResponse.id of type schemaregistry.ID",
+		},
+		{
+			name:     "Error - Empty schema",
+			schema:   tagsSchemaStr,
+			schemaID: schemaregistry.ID(10),
+			subject:  schemaregistry.Subject("mysubject"),
+			httpResponse: map[string]interface{}{
+				"id":      schemaregistry.ID(10),
+				"subject": schemaregistry.Subject("mysubject"),
+				"version": 1,
+				"schema":  "",
+			},
+			statusCode:    200,
+			expectedError: "implschemaregistry.repository.GetIDBySchema: avro: unknown type: ",
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "/subjects/mysubject", req.URL.String())
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "application/vnd.schemaregistry+json", req.Header.Get("Content-Type"))
+
+				var body map[string]interface{}
+				err := json.NewDecoder(req.Body).Decode(&body)
+				assert.NoError(t, err)
+				assert.Equal(t, body["schema"], test.schema)
+				rw.WriteHeader(test.statusCode)
+				out, _ := json.Marshal(test.httpResponse)
+				_, _ = rw.Write(out)
+			}))
+			defer server.Close()
+
+			repository := MustNew(server.URL, server.Client())
+			id, schema, err := repository.GetIDBySchema(context.Background(), test.subject, test.schema)
+			if test.expectedError != "" {
+				assert.EqualError(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.schemaID, id)
+				assert.Equal(t, test.schema, schema.String())
+			}
+		})
+	}
+}
+
+func TestMustNewPanic(t *testing.T) {
+	assert.Panics(t, func() {
+		MustNew("", nil)
+	})
+}

--- a/schemaregistry/repository.go
+++ b/schemaregistry/repository.go
@@ -1,0 +1,34 @@
+package schemaregistry
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hamba/avro"
+	"github.com/rs/zerolog"
+)
+
+// ID is the schema registry's schema ID
+type ID int
+
+// MarshalZerologObject implements the zerolog marshaler so it can be logged
+// using: log.With().EmbedObject(id).Msg("Some message")
+func (i ID) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("schemaregistry_id", strconv.Itoa(int(i)))
+}
+
+// Subject is the schema registry's subject for schemas
+type Subject string
+
+// Repository is responsible for retrieving schemas for a given ID
+type Repository interface {
+	GetSchemaByID(
+		ctx context.Context,
+		id ID,
+	) (avro.Schema, error)
+	GetIDBySchema(
+		ctx context.Context,
+		subject Subject,
+		schema string,
+	) (ID, avro.Schema, error)
+}


### PR DESCRIPTION
Avroutil is useful to encode, decode and mock a message in Avro format.

Schemaregistry is useful to manage a avro schema registry repository.