### PR TITLE
Add `stringsutil` package for utility functions to handle strings

### DIFF
--- a/stringsutil/truncate.go
+++ b/stringsutil/truncate.go
@@ -1,0 +1,11 @@
+package stringutils
+
+// Truncate cuts a given string if it's longer than the given size. Else it returns the string as is.
+func Truncate(str string, size int) string {
+	if len(str) <= size {
+		return str
+	}
+
+	runes := []rune(str)
+	return string(runes[:size])
+}

--- a/stringsutil/truncate_test.go
+++ b/stringsutil/truncate_test.go
@@ -1,0 +1,51 @@
+package stringutils
+
+import (
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	type input struct {
+		str  string
+		size int
+	}
+	tests := []struct {
+		name     string
+		input    input
+		expected string
+	}{
+		{
+			name:     "Size bigger than string",
+			input:    input{str: "pudim", size: 100},
+			expected: "pudim",
+		},
+		{
+			name:     "Size same as string",
+			input:    input{str: "flan", size: 4},
+			expected: "flan",
+		},
+		{
+			name:     "Size less than string",
+			input:    input{str: "marshmallow", size: 3},
+			expected: "mar",
+		},
+		{
+			name:     "Size less than string (with UTF-8)",
+			input:    input{str: "mãrshmallow", size: 3},
+			expected: "mãr",
+		},
+		{
+			name:     "Size is zero",
+			input:    input{str: "anything goes", size: 0},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		actual := Truncate(test.input.str, test.input.size)
+		assert.Equal(t, test.expected, actual, "[%s] Unexpected value", test.name)
+
+	}
+}

--- a/stringsutil/truncate_test.go
+++ b/stringsutil/truncate_test.go
@@ -46,6 +46,5 @@ func TestTruncate(t *testing.T) {
 	for _, test := range tests {
 		actual := Truncate(test.input.str, test.input.size)
 		assert.Equal(t, test.expected, actual, "[%s] Unexpected value", test.name)
-
 	}
 }


### PR DESCRIPTION
We have a bunch of projects that reimplement the same set of functions to handle strings. It's time to move that to here.

For now, we added only the function `Truncate`.