### PR TITLE
Fix `stringutil` package name

### DIFF
--- a/stringsutil/truncate.go
+++ b/stringsutil/truncate.go
@@ -1,4 +1,4 @@
-package stringutils
+package stringutil
 
 // Truncate cuts a given string if it's longer than the given size. Else it returns the string as is.
 func Truncate(str string, size int) string {

--- a/stringsutil/truncate_test.go
+++ b/stringsutil/truncate_test.go
@@ -1,4 +1,4 @@
-package stringutils
+package stringutil
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
The package name does not match the directory name. This PR fixes it.