### PR TITLE
Package `stringsutil`'s name  is incorrectly written

### DIFF
--- a/stringsutil/truncate.go
+++ b/stringsutil/truncate.go
@@ -1,4 +1,4 @@
-package stringutil
+package stringsutil
 
 // Truncate cuts a given string if it's longer than the given size. Else it returns the string as is.
 func Truncate(str string, size int) string {

--- a/stringsutil/truncate_test.go
+++ b/stringsutil/truncate_test.go
@@ -1,4 +1,4 @@
-package stringutil
+package stringsutil
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
The `stringsutil` package name is causing a bit of confusion. The package's folder and the package's name have slightly different names. This PR fixes it.