### PR TITLE
Add `ref`, a pointer helper package

### DIFF
--- a/ref/conversions.go
+++ b/ref/conversions.go
@@ -1,0 +1,38 @@
+package ref
+
+import (
+	"time"
+)
+
+// Str gets the pointer of the @input
+func Str(input string) *string {
+	return &input
+}
+
+// AsStr gets the value of @input. It returns zero value if @input is nil.
+func AsStr(input *string) string {
+	if input != nil {
+		return *input
+	}
+	return ""
+}
+
+// Bool gets the pointer of the @input
+func Bool(input bool) *bool {
+	return &input
+}
+
+// UInt64 gets the pointer of the @input
+func UInt64(input uint64) *uint64 {
+	return &input
+}
+
+// Time gets the pointer of the @input
+func Time(input time.Time) *time.Time {
+	return &input
+}
+
+// Float64 gets the pointer of the @input
+func Float64(input float64) *float64 {
+	return &input
+}

--- a/ref/conversions_test.go
+++ b/ref/conversions_test.go
@@ -1,0 +1,42 @@
+package ref
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStr(t *testing.T) {
+	value := "abcde"
+	assert.Equal(t, Str(value), &value)
+}
+
+func TestBool(t *testing.T) {
+	valueTrue := true
+	assert.Equal(t, Bool(valueTrue), &valueTrue)
+
+	valueFalse := false
+	assert.Equal(t, Bool(valueFalse), &valueFalse)
+}
+
+func TestFloat64(t *testing.T) {
+	value := 1.2
+	assert.Equal(t, Float64(value), &value)
+}
+
+func TestAsStr(t *testing.T) {
+	value := "bla"
+	assert.Equal(t, AsStr(&value), value)
+	assert.Equal(t, AsStr(nil), "")
+}
+
+func TestTime(t *testing.T) {
+	value := time.Now()
+	assert.Equal(t, Time(value), &value)
+}
+
+func TestUInt64(t *testing.T) {
+	value := uint64(1)
+	assert.Equal(t, UInt64(value), &value)
+}


### PR DESCRIPTION
Throughout our codebase, it's a very common boilerplate pointer
manipulations like bellow:

```
func someFunction(v *string...){...}
// Now using calling the function
value = "some string"
someFunction(&value, ...)
```

Using the `ref` package we can simplify that calling
```someFunction(ref.Str("some string"))```