### PR TITLE
Add `apiutil`, a package with some standardized API machineries

### DIFF
--- a/apiutil/encoding.go
+++ b/apiutil/encoding.go
@@ -1,0 +1,13 @@
+package apiutil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// EncodeJSONResponse encodes an endpoint response into json
+func EncodeJSONResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	return json.NewEncoder(w).Encode(response)
+}

--- a/apiutil/entity_base_response.go
+++ b/apiutil/entity_base_response.go
@@ -1,0 +1,25 @@
+package apiutil
+
+import (
+	"context"
+
+	"github.com/arquivei/foundationkit/request"
+	"github.com/arquivei/foundationkit/trace"
+)
+
+// BaseEndpointResponse should be used to extend responses from endpoint
+type BaseEndpointResponse struct {
+	// Example: "51e8cb62dbc57774a7720ef828e96c34"
+	TraceID   trace.ID    `json:"trace_id,omitempty"` // [Legacy] Already exists in Trace.
+	Trace     trace.Trace `json:"trace,omitempty"`
+	RequestID request.ID  `json:"request_id,omitempty"`
+}
+
+// CreateBaseEndpointResponse creates and returns a struct of BaseEndpointResponse filled with data from context and error.
+func CreateBaseEndpointResponse(ctx context.Context) BaseEndpointResponse {
+	return BaseEndpointResponse{
+		TraceID:   trace.GetIDFromContext(ctx), // [Legacy] Already exists in Trace.
+		Trace:     trace.GetFromContext(ctx),
+		RequestID: request.GetIDFromContext(ctx),
+	}
+}

--- a/apiutil/entity_error.go
+++ b/apiutil/entity_error.go
@@ -1,0 +1,39 @@
+package apiutil
+
+import "github.com/arquivei/foundationkit/errors"
+
+const (
+	// ErrCodeInternal is returned when an internal error happens.
+	ErrCodeInternal = errors.Code("INTERNAL_ERROR")
+
+	// ErrCodeBadRequest is returned when an error happens due to request data.
+	ErrCodeBadRequest = errors.Code("BAD_REQUEST")
+
+	// ErrCodeTimeout is returned then the request returns an error due to a timeout.
+	ErrCodeTimeout = errors.Code("REQUEST_TIMEOUT")
+)
+
+// ErrorDescription represents the detailed returned error in all APIs
+type ErrorDescription struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// ParseError parses @err in a ErrorDescription
+func ParseError(err error) ErrorDescription {
+	// This should never happen, but...
+	if err == nil {
+		return ErrorDescription{
+			Code:    ErrCodeInternal.String(),
+			Message: "trying to encode nil error",
+		}
+	}
+	code := errors.GetCode(err)
+	if code == errors.CodeEmpty {
+		code = ErrCodeInternal
+	}
+	return ErrorDescription{
+		Code:    code.String(),
+		Message: errors.GetRootErrorWithKV(err).Error(),
+	}
+}

--- a/apiutil/entity_error_encoder.go
+++ b/apiutil/entity_error_encoder.go
@@ -1,0 +1,63 @@
+package apiutil
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/request"
+	"github.com/arquivei/foundationkit/trace"
+	"github.com/rs/zerolog/log"
+)
+
+// GetHTTPStatusFunc is a type of function that should
+// take an error and return an HTTP status code.
+type GetHTTPStatusFunc func(error) int
+
+// ParseErrorFunc is a type of function that should
+// take an error parses in a struct.
+type ParseErrorFunc func(context.Context, error) interface{}
+
+// NewHTTPErrorJSONEncoder returns a new
+func NewHTTPErrorJSONEncoder(
+	getHTTPStatus GetHTTPStatusFunc,
+	parseErrorFunc ParseErrorFunc,
+) func(context.Context, error, http.ResponseWriter) {
+	if getHTTPStatus == nil {
+		panic("getHTTPStatus is nil")
+	}
+
+	return func(ctx context.Context, err error, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+		resp := parseErrorFunc(ctx, err)
+
+		w.WriteHeader(getHTTPStatus(err))
+		if encodeErr := json.NewEncoder(w).Encode(resp); encodeErr != nil {
+			log.Error().Err(errors.E(err, errors.KV("encode", encodeErr))).
+				EmbedObject(trace.GetFromContext(ctx)).
+				EmbedObject(request.GetIDFromContext(ctx)).
+				Msg("Failed to write endpoint error response")
+		}
+	}
+}
+
+// GetDefaultErrorHTTPStatusCode returns an HTTP status code base on an error.
+//
+// This is a default implementation that sets the satus code base on the error
+// severity.
+func GetDefaultErrorHTTPStatusCode(err error) (s int) {
+	switch errors.GetSeverity(err) {
+	case errors.SeverityInput:
+		return http.StatusBadRequest
+	}
+
+	switch errors.GetCode(err) {
+	case ErrCodeTimeout:
+		return http.StatusRequestTimeout
+	}
+
+	// If we don't know what happend...
+	return http.StatusInternalServerError
+}

--- a/apiutil/entity_error_encoder.go
+++ b/apiutil/entity_error_encoder.go
@@ -47,6 +47,7 @@ func NewHTTPErrorJSONEncoder(
 //
 // This is a default implementation that sets the satus code base on the error
 // severity.
+// nolint:gocritic
 func GetDefaultErrorHTTPStatusCode(err error) (s int) {
 	switch errors.GetSeverity(err) {
 	case errors.SeverityInput:
@@ -58,6 +59,6 @@ func GetDefaultErrorHTTPStatusCode(err error) (s int) {
 		return http.StatusRequestTimeout
 	}
 
-	// If we don't know what happend...
+	// If we don't know what happened...
 	return http.StatusInternalServerError
 }


### PR DESCRIPTION
In many projects, we need some boilerplate functions to deal with
some APIs that follow Gokit architecture. Also, we need a standardized
way to create some kinds of API responses (errors responses, for example).
For that purpose,  `apiutil` was created.