### PR TITLE
Add gzip package for facilitated compression/decompression capabilities

### DIFF
--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -1,0 +1,62 @@
+package gzip
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	"github.com/arquivei/foundationkit/errors"
+)
+
+// Compress the @input using the gzip format
+func Compress(input []byte) ([]byte, error) {
+	const op = errors.Op("gzip.Compress")
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(input)
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	err = zw.Close()
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	return buf.Bytes(), nil
+}
+
+// MustCompress compresses @input using gzip, and panic if it fails
+func MustCompress(input []byte) []byte {
+	const op = errors.Op("gzip.MustCompress")
+	output, err := Compress(input)
+	if err != nil {
+		panic(errors.E(op, err))
+	}
+	return output
+}
+
+// Decompress @input in the gzip format
+func Decompress(input []byte) ([]byte, error) {
+	const op = errors.Op("gzip.Decompress")
+	b := bytes.NewReader(input)
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		return nil, errors.E(op, err, errors.KV("step", "gzip.NewReader"))
+	}
+
+	var responseBuffer bytes.Buffer
+	_, err = responseBuffer.ReadFrom(r)
+	if err != nil {
+		return nil, errors.E(op, err, errors.KV("step", "responseBuffer.ReadFrom"))
+	}
+
+	return responseBuffer.Bytes(), nil
+}
+
+// MustDecompress decompresses @input in the gzip format, and panic if it fails
+func MustDecompress(input []byte) []byte {
+	const op = errors.Op("gzip.MustDecompress")
+	output, err := Decompress(input)
+	if err != nil {
+		panic(errors.E(op, err))
+	}
+	return output
+}

--- a/gzip/gzip_test.go
+++ b/gzip/gzip_test.go
@@ -1,0 +1,40 @@
+package gzip
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGunzip(t *testing.T) {
+	validGzip := []byte{0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xca, 0xcf, 0x4, 0x4, 0x0, 0x0, 0xff, 0xff, 0x6b, 0xbc, 0xd2, 0x97, 0x2, 0x0, 0x0, 0x0}
+	output, err := Decompress(validGzip)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("oi"), output)
+
+	invalidGzip := []byte("invalid")
+	_, err = Decompress(invalidGzip)
+	assert.Error(t, err)
+
+	assert.NotPanics(t, func() {
+		output := MustDecompress(validGzip)
+		assert.Equal(t, []byte("oi"), output)
+	})
+
+	assert.Panics(t, func() {
+		MustDecompress(invalidGzip)
+	})
+}
+
+func TestGzip(t *testing.T) {
+	expectedGzip := []byte{0x1f, 0x8b, 0x8, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xca, 0xcf, 0x4, 0x4, 0x0, 0x0, 0xff, 0xff, 0x6b, 0xbc, 0xd2, 0x97, 0x2, 0x0, 0x0, 0x0}
+	validInput := []byte("oi")
+	output, err := Compress(validInput)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedGzip, output)
+
+	assert.NotPanics(t, func() {
+		output := MustCompress(validInput)
+		assert.Equal(t, expectedGzip, output)
+	})
+}


### PR DESCRIPTION
We use `gzip`  extensively for compression and decompression throughout our
projects. But using  Golang's `compression/gzip` directly is overwhelming and
demands lots of boilerplate code, so we created a package that wraps the native
implementation and exposes a more straightforward API.