### PR TITLE
Fix apiutil.ParseError

### DIFF
--- a/apiutil/entity_error.go
+++ b/apiutil/entity_error.go
@@ -28,12 +28,26 @@ func ParseError(err error) ErrorDescription {
 			Message: "trying to encode nil error",
 		}
 	}
-	code := errors.GetCode(err)
-	if code == errors.CodeEmpty {
-		code = ErrCodeInternal
-	}
 	return ErrorDescription{
-		Code:    code.String(),
+		Code:    getErrorCode(err).String(),
 		Message: errors.GetRootErrorWithKV(err).Error(),
+	}
+}
+
+func getErrorCode(err error) errors.Code {
+	switch code := errors.GetCode(err); code {
+	case errors.CodeEmpty:
+		return getErrorCodeBasedOnSeverity(errors.GetSeverity(err))
+	default:
+		return code
+	}
+}
+
+func getErrorCodeBasedOnSeverity(code errors.Severity) errors.Code {
+	switch code {
+	case errors.SeverityInput:
+		return ErrCodeBadRequest
+	default:
+		return ErrCodeInternal
 	}
 }


### PR DESCRIPTION
The ParseError function extracts an error code and description to be
used on a HTTP response. The problem is that the default function for
getting an HTTP status code considers SeverityInput as a Bad Request but
the ParseError sets the error code as ErrCodeInternal. This caused
confusion for users in some APIs.

The ParseError was altered to return ErrCodeBadRequest when there is no
code but the severity is SeverityInput. So both HTTP Status Code and
Error Code are consistent.