### PR TITLE
Metrics middleware v2

### DIFF
--- a/gokitmiddlewares/metricsmiddleware/v2/config.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/config.go
@@ -1,0 +1,40 @@
+package metricsmiddleware
+
+import (
+	"github.com/arquivei/foundationkit/metrifier"
+)
+
+// Config is used to configure a metrics middleware.
+type Config struct {
+	// Metrifier is the metrifier configuration
+	Metrifier metrifier.Config
+
+	// LabelsDecoder extracts labels from the request, response or error.
+	// This is optional, can be nil
+	LabelsDecoder LabelsDecoder
+
+	// ExternalMetrics is executed after the main metrifier is called.
+	// This is intended to calculate custom metrics.
+	// This is optional, can be nil.
+	ExternalMetrics ExternalMetrics
+}
+
+// WithLabelsDecoder TODO
+func (c Config) WithLabelsDecoder(d LabelsDecoder) Config {
+	c.LabelsDecoder = d
+	c.Metrifier.ExtraLabels = d.Labels()
+	return c
+}
+
+// WithExternalMetrics TODO
+func (c Config) WithExternalMetrics(m ExternalMetrics) Config {
+	c.ExternalMetrics = m
+	return c
+}
+
+// NewDefaultConfig returns a new Config with sane defaults.
+func NewDefaultConfig(system, subsystem string) Config {
+	return Config{
+		Metrifier: metrifier.NewDefaultConfig(system, subsystem),
+	}
+}

--- a/gokitmiddlewares/metricsmiddleware/v2/config.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/config.go
@@ -19,14 +19,14 @@ type Config struct {
 	ExternalMetrics ExternalMetrics
 }
 
-// WithLabelsDecoder TODO
+// WithLabelsDecoder adds a LabelsDecoder to the metrics middleware.
 func (c Config) WithLabelsDecoder(d LabelsDecoder) Config {
 	c.LabelsDecoder = d
 	c.Metrifier.ExtraLabels = d.Labels()
 	return c
 }
 
-// WithExternalMetrics TODO
+// WithExternalMetrics adds ExternalMetrics to the metrics middleware.
 func (c Config) WithExternalMetrics(m ExternalMetrics) Config {
 	c.ExternalMetrics = m
 	return c

--- a/gokitmiddlewares/metricsmiddleware/v2/example/main.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/example/main.go
@@ -1,0 +1,90 @@
+// This is a simple example that shows how to setup the metrics middleware.
+// This can be run with `go run main.go`
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/arquivei/foundationkit/gokitmiddlewares/metricsmiddleware/v2"
+
+	"github.com/go-kit/kit/endpoint"
+	kitprometheus "github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// request is a request to the greeter endpoint
+type request struct {
+	Name string
+}
+
+// response is the response of the greeter endpoint
+type response struct {
+	Message string
+}
+
+// greeter is an endpoint that takes a name and says hello.
+func greeter(_ context.Context, req interface{}) (interface{}, error) {
+	resp := response{
+		Message: "Hello " + req.(request).Name + "!",
+	}
+
+	return resp, nil
+}
+
+// labelsDecoder is an example that creates labels for the greeter endpoint.
+type labelsDecoder struct{}
+
+func (labelsDecoder) Labels() []string {
+	return []string{"empty_name"}
+}
+
+func (labelsDecoder) Decode(ctx context.Context, req, resp interface{}, err error) map[string]string {
+	if req.(request).Name == "" {
+		return map[string]string{"empty_name": "true"}
+	}
+	return map[string]string{"empty_name": "false"}
+}
+
+// newExternalMetrics is an example on how to implement external metrics.
+func newExternalMetrics(system, subsystem string) func(ctx context.Context, req, resp interface{}, err error) {
+	count := kitprometheus.NewCounterFrom(stdprometheus.CounterOpts{
+		Namespace: system,
+		Subsystem: subsystem,
+		Name:      "letters",
+		Help:      "Total amount letters.",
+	}, nil)
+
+	return func(ctx context.Context, req, resp interface{}, err error) {
+		count.Add((float64(len(req.(request).Name))))
+	}
+}
+
+func main() {
+	// Just some basic logger initialization
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	// Create some endpoint
+	e := greeter
+
+	// Chain metrics middleware
+	e = endpoint.Chain(
+		metricsmiddleware.MustNew(
+			metricsmiddleware.NewDefaultConfig("system", "subsystem").
+				WithLabelsDecoder(labelsDecoder{}).
+				WithExternalMetrics(newExternalMetrics("system", "subsystem")),
+		),
+	)(e)
+
+	// Let's just run the example for fun.
+	ctx := context.Background()
+	req := request{Name: "World"}
+	resp, err := e(ctx, req)
+	if err != nil {
+		log.Fatal().Err(err).Msg("")
+	}
+	log.Info().Msg(resp.(response).Message)
+}

--- a/gokitmiddlewares/metricsmiddleware/v2/external_metrics.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/external_metrics.go
@@ -1,0 +1,8 @@
+package metricsmiddleware
+
+import "context"
+
+// ExternalMetrics is called after the internal metrifier is called.
+// This functions should compute other metrics that are not computed by
+// the internal metrifier (request latency and count).
+type ExternalMetrics func(ctx context.Context, req, resp interface{}, err error)

--- a/gokitmiddlewares/metricsmiddleware/v2/labels.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/labels.go
@@ -4,8 +4,10 @@ import "context"
 
 // LabelsDecoder defines an interface to decode labels for the internal metrifier.
 type LabelsDecoder interface {
-	// Labels return the complete list of all available labels that will be returned by the Decoder.
+	// Labels return the complete list of all available labels that will be
+	// returned by the Decoder. This is called once during setup of the middleware.
 	Labels() []string
 	// Decode extracts a map of labels considering the request, response and error.
+	// The map returned must contain only labels returned by the Labels() function.
 	Decode(ctx context.Context, req, resp interface{}, err error) map[string]string
 }

--- a/gokitmiddlewares/metricsmiddleware/v2/labels.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/labels.go
@@ -1,0 +1,11 @@
+package metricsmiddleware
+
+import "context"
+
+// LabelsDecoder defines an interface to decode labels for the internal metrifier.
+type LabelsDecoder interface {
+	// Labels return the complete list of all available labels that will be returned by the Decoder.
+	Labels() []string
+	// Decode extracts a map of labels considering the request, response and error.
+	Decode(ctx context.Context, req, resp interface{}, err error) map[string]string
+}

--- a/gokitmiddlewares/metricsmiddleware/v2/middleware.go
+++ b/gokitmiddlewares/metricsmiddleware/v2/middleware.go
@@ -1,0 +1,65 @@
+package metricsmiddleware
+
+import (
+	"context"
+
+	"github.com/arquivei/foundationkit/errors"
+	"github.com/arquivei/foundationkit/gokitmiddlewares"
+	logutil "github.com/arquivei/foundationkit/log"
+	"github.com/arquivei/foundationkit/metrifier"
+	"github.com/go-kit/kit/endpoint"
+	"github.com/rs/zerolog/log"
+)
+
+// MustNew returns a new metrics middleware but panics in case of error.
+func MustNew(c Config) endpoint.Middleware {
+	return gokitmiddlewares.Must(New(c))
+}
+
+// New returns a new metrics middleware.
+func New(c Config) (endpoint.Middleware, error) {
+	m, err := metrifier.New(c.Metrifier)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		log.Debug().Str("config", logutil.Flatten(c)).Msg("New metrics endpoint middleware")
+
+		return func(ctx context.Context, req interface{}) (resp interface{}, err error) {
+			defer func(s metrifier.Span) {
+				var r interface{}
+				// Panics are handled as errors and re-raised
+				if r = recover(); r != nil {
+					err = errors.E(errors.NewFromRecover(r), errors.SeverityFatal, errors.CodePanic)
+					log.Ctx(ctx).Warn().Err(err).
+						Msg("Metrics endpoint middleware is handling an uncaught a panic. Please fix it!")
+				}
+				metrify(ctx, c.LabelsDecoder, s, req, resp, err)
+				if c.ExternalMetrics != nil {
+					c.ExternalMetrics(ctx, req, resp, err)
+				}
+
+				// re-raise panic
+				if r != nil {
+					panic(r)
+				}
+			}(m.Begin())
+			return next(ctx, req)
+		}
+	}, nil
+}
+
+func metrify(ctx context.Context, labelsDecoder LabelsDecoder, s metrifier.Span, req, resp interface{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Ctx(ctx).Error().
+				Err(errors.NewFromRecover(r)).
+				Msg("Metrics middleware panicked! Please check your code and configuration.")
+		}
+	}()
+	if labelsDecoder != nil {
+		s = s.WithLabels(labelsDecoder.Decode(ctx, req, resp, err))
+	}
+	s.End(err)
+}

--- a/trace/v2/config.go
+++ b/trace/v2/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	}
 }
 
-// Setup use @c to setup an trace exporter and returns a shutdown handler
+// Setup use Config to setup an trace exporter and returns a shutdown handler
 func Setup(c Config) app.ShutdownFunc {
 	var exporter trace.SpanExporter
 


### PR DESCRIPTION
This is a proposal on how can we change and extend the metrics
middleware to handle more cases.

The Labels decoder was changed to an interface that also returns the
list of labels supported, so the middleware automatically configures the
internal metrifier.

The config now works as a builder so it can be used like this
`NewDefaultConfig().WithX().WithY()`.

There is a new option that is called ExternalMetrics. This is a
function that can be set and will be called passing the request,
response and error. This is done after the internal metrifier computes
the metrics.