### PR TITLE
Fix Code Owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @eric-reis
-* @rjfonseca
+* @eric-reis @rjfonseca


### PR DESCRIPTION
The formatting of the file was wrong and only one person was marked as
the code owner instead of the two on the file.