### PR TITLE
Fixes panics on log.Flatten

### DIFF
--- a/log/flatten.go
+++ b/log/flatten.go
@@ -36,6 +36,10 @@ func flattenPrefixed(value interface{}, prefix string) map[string]interface{} {
 }
 
 func flattenPrefixedToResult(value interface{}, prefix string, m map[string]interface{}) {
+	if value == nil {
+		return
+	}
+
 	base := ""
 	if prefix != "" {
 		base = prefix + "."

--- a/log/flatten_test.go
+++ b/log/flatten_test.go
@@ -50,4 +50,10 @@ func TestFlatten(t *testing.T) {
 	}
 	expectedFlattenE := `FooE1: '5'`
 	assert.Equal(t, expectedFlattenE, Flatten(structE), "test failed for struct E")
+
+	assert.NotPanics(t, func() {
+		Flatten(nil)
+	})
+
+	assert.Equal(t, "", Flatten(nil))
 }


### PR DESCRIPTION
A panic occurred when the given value was nil.

Now the function checks for nil and returns immediately.