### PR TITLE
[loggingmiddleware] Fix poor Zerolog usage

### DIFF
--- a/gokitmiddlewares/loggingmiddleware/loggercontext.go
+++ b/gokitmiddlewares/loggingmiddleware/loggercontext.go
@@ -10,13 +10,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func initLoggerContext(ctx context.Context, l zerolog.Logger) (*zerolog.Logger, context.Context) {
+func initLoggerContext(ctx context.Context, l zerolog.Logger) context.Context {
 	// Creates a copy, otherwise the logger is updated for every request
 	// Ensures that there is a logger in the context
 	// If the same logger is in the context already or if there is a disabled
 	// logger already in the context, the context is not updated.
 	logger := l.With().Logger()
-	return &logger, logger.WithContext(ctx)
+	return logger.WithContext(ctx)
 }
 
 func enrichLoggerContext(ctx context.Context, l *zerolog.Logger, c Config, req interface{}) {

--- a/gokitmiddlewares/loggingmiddleware/middleware.go
+++ b/gokitmiddlewares/loggingmiddleware/middleware.go
@@ -39,7 +39,8 @@ func New(c Config) (endpoint.Middleware, error) {
 		return func(ctx context.Context, req interface{}) (resp interface{}, err error) {
 			begin := time.Now()
 
-			l, ctx := initLoggerContext(ctx, *c.Logger)
+			ctx = initLoggerContext(ctx, *c.Logger)
+			l := log.Ctx(ctx)
 
 			enrichLoggerContext(ctx, l, c, req)
 			ctx = doCustomEnrichRequest(ctx, c, l, req)


### PR DESCRIPTION
Problem:

The loggingmiddleware in gokitmiddlewares uses the Update Context
capabilities from Zerolog loggers. However, some systems that updated
Zerolog to version 1.27.0 had log corruption.

Solution:

Upon investigating changes in Zerolog v1.27.0, it was found that Zerolog
changed the behavior of the function WithContext, changing it's receiver
from a pointer to a copy - and then making needed adjustements.

The loggingmiddleware uses a function 'initLogger' which would register
a logger into the received context and then return both the logger and
context. The logger returned and the logger registered in the context
were the same but, with the Zerolog changes, now they are different
loggers. Since some memory is shared in Zerolog implementation, using
the returned logger and the logger in the context results in data
overwritting and thus logs corruption.

The problem has been fixed by only returning the context with the added
logger, forcing the middleware to fetch the logger from the context.