### PR TITLE
[app] Add ReadHeaderTimeout to app http.Server

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -101,8 +101,9 @@ func New(ctx context.Context, adminPort string) (*App, error) {
 		mux.HandleFunc("/debug/dump/memstats", dumpMemStats)
 
 		server := http.Server{
-			Addr:    ":" + adminPort,
-			Handler: mux,
+			Addr:              ":" + adminPort,
+			Handler:           mux,
+			ReadHeaderTimeout: 60 * time.Second,
 		}
 		//nolint:errcheck
 		go server.ListenAndServe()


### PR DESCRIPTION
Golangci-lint detected a vulnerability issue within the 'app' package
when instantiating the http server for listening. The
'ReadHeaderTimeout' config was not set, allowing "incomplete" http
connections to hang on, indefinitely consuming system resources.