### PR TITLE
Add 'app.ServerOption' to make 'app' more configurable.

### DIFF
--- a/app/appoptions/appoptions.go
+++ b/app/appoptions/appoptions.go
@@ -1,0 +1,33 @@
+package appoptions
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/arquivei/foundationkit/app"
+)
+
+// WithReadTimeout will apply @timeout to ReadTimeout of the http server
+func WithReadTimeout(timeout time.Duration) app.ServerOption {
+	return func(server *http.Server) error {
+		server.ReadTimeout = timeout
+		return nil
+	}
+}
+
+// WithReadHeaderTimeout will apply @timeout to ReadHeaderTimeout of the
+// http server
+func WithReadHeaderTimeout(timeout time.Duration) app.ServerOption {
+	return func(server *http.Server) error {
+		server.ReadHeaderTimeout = timeout
+		return nil
+	}
+}
+
+// WithReadTimeout will apply @timeout to WriteTimeout of the http server
+func WithWriteTimeout(timeout time.Duration) app.ServerOption {
+	return func(server *http.Server) error {
+		server.WriteTimeout = timeout
+		return nil
+	}
+}

--- a/app/default.go
+++ b/app/default.go
@@ -20,8 +20,8 @@ var (
 
 // NewDefaultApp creates and sets the default app. The default app is controlled by
 // public functions in app package
-func NewDefaultApp(ctx context.Context) (err error) {
-	defaultApp, err = New(ctx, DefaultAdminPort)
+func NewDefaultApp(ctx context.Context, adminServerOptions ...ServerOption) (err error) {
+	defaultApp, err = New(ctx, DefaultAdminPort, adminServerOptions...)
 	if err != nil {
 		return err
 	}

--- a/app/examples/servefiles/main.go
+++ b/app/examples/servefiles/main.go
@@ -9,8 +9,10 @@ package main
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/arquivei/foundationkit/app"
+	"github.com/arquivei/foundationkit/app/appoptions"
 	"github.com/arquivei/foundationkit/log"
 )
 
@@ -28,10 +30,16 @@ func main() {
 	app.SetupConfig(&config)
 	ctx := log.SetupLoggerWithContext(context.Background(), config.Log, version)
 
-	// New app
-	app.NewDefaultApp(ctx)
+	// New app. Passing a write timeout configuration
+	// as an example of the Option pattern usage. The second
+	// paramater onwards can be omitted, and default values will be
+	// used.
+	app.NewDefaultApp(
+		ctx,
+		appoptions.WithWriteTimeout(10*time.Second),
+	)
 
-	// Some inicialization, could take a while.
+	// Some initialization, could take a while.
 	// It's a good practice to initialize everything before calling RunAndWait because
 	// readiness probe is already up and reporting the app is not ready yet.
 	httpServer := &http.Server{Addr: ":" + config.HTTP.Port, Handler: http.FileServer(http.Dir(config.Dir))}

--- a/app/option.go
+++ b/app/option.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"net/http"
+)
+
+// ServerOption is an interface to Options that can be used to configure a
+// http server configured behavior. Ready-to-use Option can be found in
+// the `appoptions` package.
+type ServerOption func(*http.Server) error
+
+// SetupServer will apply @options on @server, in the order that they
+// are declared. If an option returns an error, this function will immediately
+// return the received error.
+func SetupServer(server *http.Server, options ...ServerOption) error {
+	for _, option := range options {
+		err := option(server)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The 'app' package has the capability to start HTTP servers for admin
usage (dumps, profiling, etc). Since the HTTP server is created and
initiated within 'app.New', there is no way to configure the HTTP server
to fit the system needs.

This commit adds 'app.ServerOption' which follows the Option pattern to
make the http server more configurable. Since most users of this package
are expected to use 'app.NewDefaultApp', the option paramaters have been
added to the function as well.

Currently, basic timeout Option have been added to 'appoptions'
subpackage.