### PR TITLE
Fix erros from linters

### DIFF
--- a/app/doc.go
+++ b/app/doc.go
@@ -7,7 +7,7 @@ The recommended way to use the `app` package is to rely on the 'default app'. Th
 
 There is a running example on `app/examples/servefiles`
 
-Basics
+# Basics
 
 The first thing you should do is setup a configuration and logger. The app uses the foundation's kit log package and expects a zerolog's logger in the context.
 
@@ -40,11 +40,11 @@ Finally you can run the application by calling RunAndWait:
 
 At this point the application will run until the given function returns or it receives an termination signal.
 
-Updating From Previous Version
+# Updating From Previous Version
 
 On the previous version,the NewDefaultApp received the main loop:
 
-   func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error)
+	func NewDefaultApp(ctx context.Context, mainLoop MainLoopFunc) (err error)
 
 This was a problem because the main loop normally depends on various resources that must be created before the main loop can be called. But the creation of this resourced involves registering shutdown handlers, that requires an already created app.
 
@@ -52,7 +52,7 @@ This cycle forced the application to rely on lazy initialization of the resource
 
 To break this cycle the main loop was moved from the NewDefaultApp and was placed on the RunAndWait function. So to update to this version you could only change these two functions calls. But, to really take advantage of this new way to start an app, you should refactor the code to remove the laziness part before the RunAndWait is called.
 
-Using Probes
+# Using Probes
 
 A Probe is a boolean that indicates if something is OK or not. There are two groups of probes in an app: The Healthiness an Readiness groups. Kubernetes checks on there two probes to decide what to do to the pod, like, from stop sending requests to just kill the pod, sending a signal the app will capture and start a graceful shutdown.
 
@@ -79,7 +79,6 @@ If a single probe of a group is not ok, than the whole group is not ok. In this 
 		}
 	})
 
-
 If the application is unhealthy kubernetes will send a signal that will trigger the graceful shutdown. All registered shutdown handlers will be executed ordered by priority (highest first) and the pod will be restarted. Only set an application as unhealthy if it reached an unworkable state and should be restarted. We have an example of this on `gokitmiddlewares/stalemiddleware/`. This is a middleware that was developed to be used in workers. It checks if the endpoint is being called (messages are being fetched and processed) and if not, it assumes there could be a problem with the queue and sets the application to unready, causing the application to restart. This mitigated a problem we had with kafka when a change of brokers made the worker stop receiving messages forever.
 
 If the application is unready kubernetes will stop sending requests, but if the application becomes ready again, it will start receiving requests. This is used during initialization to signalize to kubernetes when the application is ready and can receive requests. If we can identify that the the application is degraded we can use this probe to temporary remove the application from the kubernetes service until it recovers.
@@ -95,6 +94,5 @@ The state of a probe can be altered at any time using SetOk and SetNotOk:
 
 	readinessProbe.SetOk()
 	readinessProbe.SetNotOk()
-
 */
 package app

--- a/avroutil/decoder_test.go
+++ b/avroutil/decoder_test.go
@@ -2,7 +2,7 @@ package avroutil
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -70,7 +70,7 @@ func TestDecode(t *testing.T) {
 }
 
 func loadFile(name string) []byte {
-	content, err := ioutil.ReadFile(filepath.Join("testdata", name))
+	content, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
 		panic(err)
 	}

--- a/avroutil/encoder.go
+++ b/avroutil/encoder.go
@@ -23,10 +23,10 @@ type implEncoder struct {
 // NewEncoder returns a concrete implementation of Decoder, that
 // fetches schemas in schema registry
 // Parameters:
-// - @schemaRepository: repository for avro schemas.
-// - @writerSchemaStr: avro schema, in the AVSC format, used to marshall the
-//   objects. This schema must be previously registered in the schema registry
-//   exactly as provided.
+//   - @schemaRepository: repository for avro schemas.
+//   - @writerSchemaStr: avro schema, in the AVSC format, used to marshall the
+//     objects. This schema must be previously registered in the schema registry
+//     exactly as provided.
 func NewEncoder(
 	ctx context.Context,
 	schemaRepository schemaregistry.Repository,

--- a/avroutil/wireformat_encoder.go
+++ b/avroutil/wireformat_encoder.go
@@ -23,10 +23,10 @@ type wireFormatEncoder struct {
 // NewWireFormatEncoder returns a concrete implementation of WireFormatEncoder, that
 // fetches schemas in schema registry
 // Parameters:
-// - @schemaRepository: repository for avro schemas.
-// - @writerSchemaStr: avro schema, in the avsc format, used to marshall the
-//   objects. This schema must be previously registered in the schema registry
-//   exactly as provided.
+//   - @schemaRepository: repository for avro schemas.
+//   - @writerSchemaStr: avro schema, in the avsc format, used to marshall the
+//     objects. This schema must be previously registered in the schema registry
+//     exactly as provided.
 func NewWireFormatEncoder(
 	ctx context.Context,
 	schemaRepository schemaregistry.Repository,

--- a/httpcomm/communicatewithjson.go
+++ b/httpcomm/communicatewithjson.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -277,7 +276,7 @@ func communicateWithHTTPRequest(
 	details.RequestID = request.GetFromHTTPResponse(httpResponse)
 
 	limitedReader := io.LimitReader(httpResponse.Body, maxAcceptedBodySize+1)
-	contents, err := ioutil.ReadAll(limitedReader)
+	contents, err := io.ReadAll(limitedReader)
 	if err != nil {
 		return details, nil, errors.E(
 			ErrCodeDecodeError,

--- a/request/doc.go
+++ b/request/doc.go
@@ -1,7 +1,7 @@
 /*
 Package request provides helper functions to handle Request ID propagation.
 
-Basics
+# Basics
 
 It will be used the following service as example:
 
@@ -13,7 +13,7 @@ It will be used the following service as example:
 		RequestID request.ID
 	}
 
-HTTP Layer
+# HTTP Layer
 
 Use the function "WithID" to create and put a Request ID in context:
 
@@ -26,7 +26,7 @@ Use the function "WithID" to create and put a Request ID in context:
 		}
 	}
 
-Logging
+# Logging
 
 Use the function "GetIDFromContext" to log the Request ID:
 
@@ -36,6 +36,5 @@ Use the function "GetIDFromContext" to log the Request ID:
 			Logger()
 		// (...)
 	}
-
 */
 package request

--- a/splitio/doc.go
+++ b/splitio/doc.go
@@ -1,7 +1,7 @@
 /*
 Package splitio provides integration with https://www.split.io/.
 
-Basics
+# Basics
 
 Using the client directly:
 
@@ -13,7 +13,7 @@ Using the client directly:
 		// do stuff
 	}
 
-Using the middleware
+# Using the middleware
 
 In the service:
 
@@ -57,6 +57,5 @@ attributes specified in the "MultiUserDecodeFn". The behavior is
 stored in the context, so that it is possible to check anywhere
 in the service if the feature is enabled without caring about
 which user or attributes should be used.
-
 */
 package splitio

--- a/trace/doc.go
+++ b/trace/doc.go
@@ -1,7 +1,7 @@
 /*
 Package trace provides distributed tracing.
 
-Initialization
+# Initialization
 
 In the config variable, add the "Config" struct:
 
@@ -27,7 +27,7 @@ Now, initialize your trace exporter using "trace.SetupTrace":
 
 	trace.SetupTrace(config.Trace)
 
-Service
+# Service
 
 It will be used the following service as example:
 
@@ -52,7 +52,7 @@ And will be used the following job as example of job/event:
 		trace.Trace
 	}
 
-HTTP Layer
+# HTTP Layer
 
 Retrieve the Trace from the HTTP request and pass it along:
 
@@ -89,7 +89,8 @@ Encode the trace in the HTTP respose:
 		trace.SetInHTTPResponse(response.Trace, w)
 		// (...)
 	}
-Using spans
+
+# Using spans
 
 Inside a service function:
 
@@ -122,7 +123,7 @@ Inside a service function:
 		//(...)
 	}
 
-Logging
+# Logging
 
 Use the function "GetIDFromContext" to log the Trace ID:
 
@@ -132,7 +133,5 @@ Use the function "GetIDFromContext" to log the Trace ID:
 			Logger()
 		// (...)
 	}
-
-
 */
 package trace


### PR DESCRIPTION
The pipeline is failing because new changes by go and the
golangci-linter.

Package `ioutil` was deprecated and is now removed from the code.

Some files where reformatted.