### PR TITLE
Increases go-report-card score

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,32 +9,29 @@ linters:
     #- golint        # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes
     #- lll           # Reports long lines
     #- scopelint     # Scopelint checks for unpinned variables in go programs
-    - bodyclose     # checks whether HTTP response body is closed successfully
-    - deadcode      # Finds unused code
-    - depguard      # Go linter that checks if package imports are in a list of acceptable packages
-    - dupl          # Tool for code clone detection
-    - errcheck      # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
+    - bodyclose # checks whether HTTP response body is closed successfully
+    - depguard # Go linter that checks if package imports are in a list of acceptable packages
+    - dupl # Tool for code clone detection
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - exportloopref # checks for pointers to enclosing loop variables
-    - goconst       # Finds repeated strings that could be replaced by a constant
-    - gocritic      # The most opinionated Go source code linter
-    - gocyclo       # Computes and checks the cyclomatic complexity of functions
-    - gofmt         # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - goimports     # Goimports does everything that gofmt does. Additionally it checks unused imports
-    - gosec         # Inspects source code for security problems
-    - gosimple      # Linter for Go source code that specializes in simplifying a code
-    - govet         # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign   # Detects when assignments to existing variables are not used
-    - misspell      # Finds commonly misspelled English words in comments
-    - nakedret      # Finds naked returns in functions greater than a specified function length
-    - noctx         # noctx finds sending http request without context.Context
-    - prealloc      # Finds slice declarations that could potentially be preallocated
-    - rowserrcheck  # checks whether Err of rows is checked successfully
-    - staticcheck   # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck   # Finds unused struct fields
-    - stylecheck    # Stylecheck is a replacement for golint
-    - typecheck     # Like the front-end of a Go compiler, parses and type-checks Go code
-    - unconvert     # Remove unnecessary type conversions
-    - unparam       # Reports unused function parameters
-    - unused        # Checks Go code for unused constants, variables, functions and types
-    - varcheck      # Finds unused global variables and constants
-    - whitespace    # Tool for detection of leading and trailing whitespace
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - gocritic # The most opinionated Go source code linter
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - goimports # Goimports does everything that gofmt does. Additionally it checks unused imports
+    - gosec # Inspects source code for security problems
+    - gosimple # Linter for Go source code that specializes in simplifying a code
+    - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign # Detects when assignments to existing variables are not used
+    - misspell # Finds commonly misspelled English words in comments
+    - nakedret # Finds naked returns in functions greater than a specified function length
+    - noctx # noctx finds sending http request without context.Context
+    - prealloc # Finds slice declarations that could potentially be preallocated
+    - rowserrcheck # checks whether Err of rows is checked successfully
+    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - stylecheck # Stylecheck is a replacement for golint
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unconvert # Remove unnecessary type conversions
+    - unparam # Reports unused function parameters
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - whitespace # Tool for detection of leading and trailing whitespace

--- a/sefaz/accesskey/validation.go
+++ b/sefaz/accesskey/validation.go
@@ -240,19 +240,25 @@ func isValidMonthDay(month string, day string) bool {
 }
 
 func isValidModel(model string) bool {
-	return model == "01" || model == "1A" ||
-		model == "02" || model == "04" ||
-		model == "06" || model == "07" ||
-		model == "08" || model == "09" ||
-		model == "10" || model == "11" ||
-		model == "13" || model == "14" ||
-		model == "15" || model == "16" ||
-		model == "18" || model == "21" ||
-		model == "22" || model == "26" ||
-		model == "55" || model == "57" ||
-		model == "59" || model == "60" ||
-		model == "63" || model == "65" ||
-		model == "67"
+	switch model {
+	case "1A",
+		"01", "02",
+		"04",
+		"06", "07", "08", "09", "10", "11",
+		"13", "14", "15", "16",
+		"18",
+		"21", "22",
+		"26",
+		"55",
+		"57",
+		"59", "60",
+		"63",
+		"65",
+		"67":
+		return true
+	default:
+		return false
+	}
 }
 
 var validationDigitMultipliers = []int{

--- a/trace/v2/examples/services/ping/apiping/http.go
+++ b/trace/v2/examples/services/ping/apiping/http.go
@@ -67,6 +67,6 @@ func getHTTPStatus(err error) (s int) {
 		return http.StatusBadRequest
 	}
 
-	// If we don't know what happend...
+	// If we don't know what happened...
 	return http.StatusInternalServerError
 }


### PR DESCRIPTION
Checking our report card, we had 2 minor issues that prevented us from getting a perfect score.

- Fixed misspell
- Fixed cyclomatic complexity above 15
- Removed deprecated linters from golangci

Links:

- https://goreportcard.com/report/github.com/arquivei/foundationkit