### PR TITLE
Adds wrap support to foundationkit error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -71,6 +71,10 @@ func (e Error) String() string {
 	return e.Error()
 }
 
+func (e Error) Unwrap() error {
+	return e.Err
+}
+
 // E is a helper function for builder errors
 func E(args ...interface{}) error {
 	e := Error{}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -70,4 +71,26 @@ func TestErrorString_NoError(t *testing.T) {
 	err := Error{}
 	stringError = err.Error()
 	assert.FailNow(t, "panic didn't occurred")
+}
+
+func TestErrorWrap(t *testing.T) {
+	rootError := testError("root error")
+
+	err := E(Op("a"), rootError)
+	assert.Equal(t, rootError, errors.Unwrap(err))
+	err = E(Op("b"), err)
+	err = E(Op("c"), err)
+	err = E(Op("d"), err)
+
+	assert.True(t, errors.Is(err, rootError))
+
+	var destError testError
+	assert.True(t, errors.As(err, &destError))
+	assert.Equal(t, rootError, destError)
+}
+
+type testError string
+
+func (e testError) Error() string {
+	return string(e)
 }


### PR DESCRIPTION
Since go 1.13, go has a new way of handling wrapped errors, with the functions errors.Is, errors.As and errors.Unwrap.

Currently, there is no easy way of extracting the root of an error. This could be useful for example: If we wrap a library that returns an error with enriched information, we could use `errors.As` to extract information about what happened internaly.