### PR TITLE
Adds wrap support for errors.GetCode and GetSeverity

### DIFF
--- a/errors/code.go
+++ b/errors/code.go
@@ -1,6 +1,10 @@
 package errors
 
-import "github.com/rs/zerolog"
+import (
+	"errors"
+
+	"github.com/rs/zerolog"
+)
 
 // Code is the error code
 type Code string
@@ -25,7 +29,9 @@ const (
 // an error code, returns ErrorCodeEmpty
 func GetCode(err error) Code {
 	for {
-		e, ok := err.(Error)
+		var e Error
+
+		ok := errors.As(err, &e)
 		if !ok {
 			break
 		}

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -94,3 +94,13 @@ type testError string
 func (e testError) Error() string {
 	return string(e)
 }
+
+func TestErrorWrapMixed(t *testing.T) {
+	err := E("root error", Code("CODE"), SeverityFatal)
+
+	err = fmt.Errorf("wrapped: %w", err)
+	err = E(Op("a"), err)
+
+	assert.Equal(t, Code("CODE"), GetCode(err))
+	assert.Equal(t, SeverityFatal, GetSeverity(err))
+}

--- a/errors/severity.go
+++ b/errors/severity.go
@@ -1,6 +1,10 @@
 package errors
 
-import "github.com/rs/zerolog"
+import (
+	"errors"
+
+	"github.com/rs/zerolog"
+)
 
 // Severity is the error severity. It's used to classify errors in groups to be easily handled by the code. For example,
 // a retry layer should be only checking for Runtime errors to retry. Or in an HTTP layer, errors of input type are always
@@ -31,7 +35,9 @@ func (s Severity) MarshalZerologObject(e *zerolog.Event) {
 // GetSeverity returns the error severity. If there is not severity, SeverityUnset is returned.
 func GetSeverity(err error) Severity {
 	for {
-		e, ok := err.(Error)
+		var e Error
+
+		ok := errors.As(err, &e)
 		if !ok {
 			break
 		}


### PR DESCRIPTION
Since the last change that added support for `errors.Is` and `errors.As` functions, it is possible to retrieve specific error types thar are wraped with foundationkit error.

But in the opposite case, when we wrap a foundationkit error with a custom error type (e.g. when adding custom information to the error that could be retrieved), we loose the current error's Code and Severity information.

Using `errors.As` instead of a simple cast `.(Error)` solves that problem.

This commit doesn't change the `GetRootError` and `GetRootErrorWithKV` functions since the semantics become tricky when dealing with mixed errors.