### PR TITLE
Add example to package avroutil

### DIFF
--- a/avroutil/example/assets/SchemaExample.avsc
+++ b/avroutil/example/assets/SchemaExample.avsc
@@ -1,0 +1,15 @@
+{
+    "name": "simple",
+    "type": "record",
+    "namespace" : "com.arquivei",
+    "fields": [
+        {
+            "name": "Field1",
+            "type": "long"
+        },
+        {
+            "name": "Field2",
+            "type": "string"
+        }
+    ]
+}

--- a/avroutil/example/avroschemas.go
+++ b/avroutil/example/avroschemas.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	// Embedding avro schemas as strings
+	_ "embed"
+
+	"github.com/arquivei/foundationkit/schemaregistry"
+)
+
+// schemaExample is an avro schema that contains all data related to SchemaExample
+//
+//go:embed assets/SchemaExample.avsc
+var schemaExample string
+
+// avroSubjectschemaExample is the subject that can be used to find the SchemaExample in a schema registry
+var avroSubjectschemaExample schemaregistry.Subject = "com.arquivei.subject"

--- a/avroutil/example/main.go
+++ b/avroutil/example/main.go
@@ -1,0 +1,69 @@
+// This is a simple example that shows how to use avroutil package.
+// This can be run with `go run main.go avroschemas.go`
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/arquivei/foundationkit/avroutil"
+	"github.com/arquivei/foundationkit/schemaregistry"
+	"github.com/arquivei/foundationkit/schemaregistry/implschemaregistry"
+)
+
+// exampleStruct is a struct that contains all fields related to SchemaExample
+type exampleStruct struct {
+	Field1 int64  `avro:"Field1"`
+	Field2 string `avro:"Field2"`
+}
+
+func main() {
+	// Just some basic logger initialization
+	zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+	// Create an example data
+	exampleData := exampleStruct{
+		Field1: 1,
+		Field2: "2",
+	}
+
+	// Setup schema registry mock to avoid external connection
+	mockSchemaRegistry := implschemaregistry.MustNewMock(map[schemaregistry.ID]string{
+		1: schemaExample,
+	})
+
+	// Create a new encoder based in schemaExample
+	encoder, err := avroutil.NewEncoder(context.Background(), mockSchemaRegistry, avroSubjectschemaExample, schemaExample)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Fail to initialize new encoder")
+	}
+
+	// Create a new decoder with mock schema registry
+	decoder := avroutil.NewDecoder(mockSchemaRegistry)
+
+	// Let's encode example data
+	encodedData, err := encoder.Encode(exampleData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Fail to encode data")
+	}
+
+	// Let's decode the output encoded data
+	var decodedData exampleStruct
+	err = decoder.Decode(context.Background(), encodedData, &decodedData)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Fail to decode data")
+	}
+
+	fmt.Printf("Example data %+v\n", exampleData)
+	fmt.Printf("Decoded data %+v\n", decodedData)
+
+	// Let's just compare the example data and output decode data for fun.
+	if exampleData == decodedData {
+		log.Info().Msg("Encoded and Decoded data with success")
+	}
+}


### PR DESCRIPTION
Package avroutil didn't have examples of using its methods.

Add examples for Encode and Decode functions.

Related to #67 