### PR TITLE
Refactor ref package to use generics

### DIFF
--- a/ref/conversions.go
+++ b/ref/conversions.go
@@ -4,12 +4,37 @@ import (
 	"time"
 )
 
+// Ptr returns a pointer to v.
+func Ptr[T any](v T) *T {
+	return &v
+}
+
+// PtrNil returns a pointer to v but if v is zero, returns nil.
+func PtrNil[T comparable](v T) *T {
+	var zero T
+	if v == zero {
+		return nil
+	}
+	return &v
+}
+
+// Val returns the value of a pointer. If the pointer is nil returns the zero value.
+func Val[T any](v *T) T {
+	var zero T
+	if v == nil {
+		return zero
+	}
+	return *v
+}
+
 // Str gets the pointer of the @input
+// Deprecated: use Ptr instead.
 func Str(input string) *string {
 	return &input
 }
 
 // AsStr gets the value of @input. It returns zero value if @input is nil.
+// Deprecated: use Ptr instead.
 func AsStr(input *string) string {
 	if input != nil {
 		return *input
@@ -18,21 +43,25 @@ func AsStr(input *string) string {
 }
 
 // Bool gets the pointer of the @input
+// Deprecated: use Ptr instead.
 func Bool(input bool) *bool {
 	return &input
 }
 
 // UInt64 gets the pointer of the @input
+// Deprecated: use Ptr instead.
 func UInt64(input uint64) *uint64 {
 	return &input
 }
 
 // Time gets the pointer of the @input
+// Deprecated: use Ptr instead.
 func Time(input time.Time) *time.Time {
 	return &input
 }
 
 // Float64 gets the pointer of the @input
+// Deprecated: use Ptr instead.
 func Float64(input float64) *float64 {
 	return &input
 }

--- a/ref/conversions_test.go
+++ b/ref/conversions_test.go
@@ -7,6 +7,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPtr(t *testing.T) {
+	strPtr := Ptr("some string")
+
+	assert.NotNil(t, strPtr)
+	assert.Equal(t, "some string", *strPtr)
+}
+
+func TestPtrNil(t *testing.T) {
+	nilStr := PtrNil("")
+	assert.Nil(t, nilStr)
+
+	someString := PtrNil("some string")
+	assert.NotNil(t, someString)
+	assert.Equal(t, "some string", *someString)
+}
+
+func TestVal(t *testing.T) {
+	var nilStr *string
+	assert.Equal(t, "", nilStr)
+
+	someString := "some string"
+	assert.Equal(t, "some string", Val(&someString))
+}
+
+// Deprecated tests
+
 func TestStr(t *testing.T) {
 	value := "abcde"
 	assert.Equal(t, Str(value), &value)


### PR DESCRIPTION
Before generics we had to have one function for each type we wanted to support. Now we can use only one function with generics.