### PR TITLE
Increases linter timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 # Full list on https://golangci-lint.run/usage/linters/
+run:
+  timeout: 5m
+  allow-parallel-runners: true
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
golangci-lint frequently fails on github due to timeout. The default timeout value is 1 minute.

This will increase the timeout to 5 minutes in hope for eliminating the issue.