### PR TITLE
Updates Go toolchain and github workflows to go1.24.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.21.4
       - name: Build
         run: go build -v ./...
 
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.21.4
       - name: Test
         run: go test -v ./...
 
@@ -43,6 +43,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.21.4
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.21.3
+          go-version: 1.21.4
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/govulcheck.yml
+++ b/.github/workflows/govulcheck.yml
@@ -18,5 +18,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.3
+          go-version-input: 1.21.4
           go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/arquivei/foundationkit
 
 go 1.21
 
-toolchain go1.21.3
+toolchain go1.21.4
 
 require (
 	cloud.google.com/go/logging v1.8.1


### PR DESCRIPTION
The version 1.24.1 solves vulnerabilities that are being detected by { govulncheck`. The base go version in `go.mod` was left unchanged, but the toolchain was updated with `go get toolchain@1.21.4` as pointed out in the toolchain documentation (currently https://go.dev/doc/toolchain)

The gitlab workflows were also updated.