### PR TITLE
[httpmiddlewares] Create new HTTP Audit Middleware

### DIFF
--- a/httpmiddlewares/auditmiddleware/middleware.go
+++ b/httpmiddlewares/auditmiddleware/middleware.go
@@ -1,0 +1,93 @@
+package auditmiddleware
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	"github.com/arquivei/foundationkit/message"
+	"github.com/rs/zerolog/log"
+)
+
+type auditResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newAuditResponseWriter(w http.ResponseWriter) *auditResponseWriter {
+	return &auditResponseWriter{w, http.StatusOK}
+}
+
+// WriteHeader is used to store the status code that will be returned by the server
+func (arw *auditResponseWriter) WriteHeader(code int) {
+	arw.statusCode = code
+	arw.ResponseWriter.WriteHeader(code)
+}
+
+// Exporter is used to push the audit message that was created using CreateAuditMessageFunc
+type Exporter interface {
+	Push(context.Context, message.Message) error
+}
+
+// CreateAuditMessageFunc is used to customize the creation of an audit message
+// using http.Request and response status code.
+type CreateAuditMessageFunc func(
+	request *http.Request,
+	responseStatusCode int,
+) (message.Message, error)
+
+// AuditMiddleware allows to create and push a customized message for every http request received
+type AuditMiddleware struct {
+	exporter               Exporter
+	createAuditMessageFunc CreateAuditMessageFunc
+}
+
+// NewAuditMiddleware returns a new AuditMiddleware with the
+// given Exporter and CreateAuditMessageFunc
+// Parameters:
+//   - @exporter: exporter that will be used to push audit messages.
+//   - @createAuditMessageFunc: function that will be used to create audit messages
+func NewAuditMiddleware(
+	exporter Exporter,
+	createAuditMessageFunc CreateAuditMessageFunc,
+) *AuditMiddleware {
+	return &AuditMiddleware{exporter, createAuditMessageFunc}
+}
+
+// New returns a new audit http handler wrapping the @next handler.
+func (a *AuditMiddleware) New(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arw := newAuditResponseWriter(w)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to get request body")
+			body = []byte{}
+		}
+		r.Body.Close()
+
+		requestClone := r.Clone(r.Context())
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		requestClone.Body = io.NopCloser(bytes.NewReader(body))
+
+		defer func() {
+			auditMessage, err := a.createAuditMessageFunc(
+				requestClone,
+				arw.statusCode,
+			)
+			if err != nil {
+				log.Warn().Err(err).Msg("failed to create audit message")
+				return
+			}
+
+			err = a.exporter.Push(context.Background(), auditMessage)
+			if err != nil {
+				log.Warn().Err(err).Msg("failed to send audit message")
+				return
+			}
+		}()
+
+		next.ServeHTTP(arw, r)
+	})
+}


### PR DESCRIPTION
Create a new http middleware called audit middleware.

The purpose of this middleware is to allow creating and pushing a customized message for every http request received.

It could be useful when we want to store requests information based on some parameters received or based on the status code returned.

The parameters availabe for creating a message is the http request itself and the response status code.

To create this middleware, user should provide an implementation of both `Exporter` and `CreateAuditMessageFunc`.

Example of usage:

```
auditMiddleware := auditmiddlewate.NewAuditMiddleware(
        getNotificationQueue(),
        myhttp.CreateEndpointWasRequestedMessage,
)

r.Use(
        gziphandler.GzipHandler,
        trackingmiddleware.New,
        enrichloggingmiddleware.New,
        auditMiddleware.New,
)
```

Depending on how the CreateAuditMessageFunc is implemented, the Push function can return an error. For example the scenario when the request body is too large. Cases like this this should be treated in the implementation of `CreateAuditMessageFunc`