### PR TITLE
Update Go in Github Actions to 1.24.5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.21.5
       - name: Build
         run: go build -v ./...
 
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.21.5
       - name: Test
         run: go test -v ./...
 
@@ -43,6 +43,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.21.5
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.4
+          go-version: 1.21.5
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/govulcheck.yml
+++ b/.github/workflows/govulcheck.yml
@@ -18,5 +18,5 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.21.4
+          go-version-input: 1.21.5
           go-package: ./...


### PR DESCRIPTION
The Go 1.24.5 has bugfixes and security fixes, some of which are triggering the current `govulcheck`.

The `toolchain` on `go.mod` was kept on Go 1.21.4.