### PR TITLE
Configure `renovate.json` to ignore `uconfig` v1.2.1 dep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
   },
   "extends": ["config:base", ":semanticCommits"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "ignoreDeps": [
+    "github.com/omeid/uconfig@v1.2.1"
+  ],
   "packageRules": [
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
The `uconfig` package is being updated to version v1.2.1, but this version has been retracted on it's `go.mod` file. Renovate Bot is attempting to update the version anyway. Since there are no changes, the update is harmless. Even so, I think it's a good idea to avoid updating to retracted versions.