### PR TITLE
Fix StartSpanWithParent panicking

### DIFF
--- a/trace/span.go
+++ b/trace/span.go
@@ -48,6 +48,7 @@ func (s *Span) GetID() SpanID {
 // Otherwise, the method will create a new span and return it
 func StartSpanWithParent(ctx context.Context, spanNameArgs ...string) (newCtx context.Context, s Span) {
 	t := GetFromContext(ctx)
+	t = ensureTraceNotEmpty(t)
 
 	parent := createSpanContext(t.ID.String(), *t.ProbabilitySample)
 

--- a/trace/span_test.go
+++ b/trace/span_test.go
@@ -163,3 +163,11 @@ func TestGetID(t *testing.T) {
 	_, s = StartSpan(ctx, "test")
 	assert.NotEmpty(t, s.GetID(), "Returned span id should not be empty")
 }
+
+func TestStartSpanWithParent(t *testing.T) {
+	assert.NotPanics(t, func() {
+		ctx := context.Background()
+		_, span := StartSpanWithParent(ctx, "tag1", "value1")
+		defer span.End(nil)
+	}, "starting a span when there is no trace in context should do panic")
+}


### PR DESCRIPTION
The function trace.StartSpanWithParent() panics when there is no trace in the context, but according to its doc, it should create a new trace.

Adds a test replicating the issue and fixes it by initializing trace if it is empty.