### PR TITLE
Update uconfig to the retracted v1.2.1 version

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -19,10 +19,12 @@ func SetupConfig(config interface{}) {
 		files = []struct {
 			Path      string
 			Unmarshal file.Unmarshal
+			Optional  bool
 		}{
 			{
 				Path:      ConfigFilename,
 				Unmarshal: json.Unmarshal,
+				Optional:  false,
 			},
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/hamba/avro/v2 v2.19.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/omeid/uconfig v1.2.0
+	github.com/omeid/uconfig v1.2.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/rs/zerolog v1.31.0
 	github.com/splitio/go-client/v6 v6.5.2

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
 github.com/oklog/ulid/v2 v2.1.0/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/omeid/uconfig v1.2.0 h1:suUh//PBoUae5K4DJF5W5YAUWrj8ZJCAw4DqT8X2xag=
-github.com/omeid/uconfig v1.2.0/go.mod h1:NlsL5XW1GQF/W8r1N1tMZWQM3oqeXxQBFAlwUOCA9ys=
+github.com/omeid/uconfig v1.2.1 h1:7BU5x7OlvlVZw3OLuMCLFL4RUnYHdAjSjjUKe0vBW4k=
+github.com/omeid/uconfig v1.2.1/go.mod h1:YBoXtiqFwV94p7hVgjBV8pWCn0hhHtqcMGEctaJQPl8=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
The insane generation of retracted versions without code of uconfig allied to the Renovate Bot insisting on updating it even if it is in ignoreDeps have proven to be formidable adversaries.

We can't win agains them.

We join them.

All hail uconfig v1.2.1 the new lord. Now please, let us work in peace =P