### PR TITLE
Fixes example of metrics middleware version 4

### DIFF
--- a/gokitmiddlewares/metricsmiddleware/v4/example/main.go
+++ b/gokitmiddlewares/metricsmiddleware/v4/example/main.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/arquivei/foundationkit/gokitmiddlewares/metricsmiddleware/v3"
+	"github.com/arquivei/foundationkit/gokitmiddlewares/metricsmiddleware/v4"
 
 	"github.com/go-kit/kit/endpoint"
 	kitprometheus "github.com/go-kit/kit/metrics/prometheus"


### PR DESCRIPTION
The example was using version 3. It was fixed to use version 4.