### PR TITLE
Refactors errors package

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -138,12 +138,12 @@ func (a *App) Shutdown(ctx context.Context) (err error) {
 
 	select {
 	case <-ctx.Done():
-		err = errors.E(op, "shutdown deadline has been reached")
+		err = errors.New("shutdown deadline has been reached", op)
 	case err = <-a.shutdownAllHandlers(ctx):
 	}
 	if err != nil {
 		log.Trace().Err(err).Msg("[app] Graceful shutdown failed.")
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	log.Trace().Msg("[app] Graceful shutdown finished successfully.")
@@ -158,7 +158,7 @@ func (a *App) shutdownAllHandlers(ctx context.Context) chan error {
 		for a.shutdownHandlers.Len() > 0 {
 			h := heap.Pop(&a.shutdownHandlers).(*ShutdownHandler)
 			if ctx.Err() != nil {
-				done <- errors.E(op, "shutdow deadline has been reached")
+				done <- errors.New("shutdow deadline has been reached", op)
 			}
 			trace := log.Trace().
 				Str("shutdown_handler_name", h.Name).
@@ -169,7 +169,7 @@ func (a *App) shutdownAllHandlers(ctx context.Context) chan error {
 			trace.Msg("[app] Executing shutdown handler.")
 			if err := h.Execute(ctx); err != nil {
 				trace.Msg("[app] Shutdown handler failed.")
-				done <- errors.E(op, err)
+				done <- errors.E(err, op)
 			}
 			trace.Msg("[app] Shutdown handler finished.")
 		}

--- a/app/shutdownhandler.go
+++ b/app/shutdownhandler.go
@@ -81,7 +81,7 @@ func (sh *ShutdownHandler) Execute(ctx context.Context) error {
 
 	// Avoid running if the context is already closed
 	if ctx.Err() != nil {
-		sh.err = errors.E(op, errors.E(errors.Op(sh.Name), "skipping handler as deadline has been reached"))
+		sh.err = errors.E(errors.New("skipping handler as deadline has been reached", errors.Op(sh.Name)), op)
 		return sh.err
 	}
 
@@ -95,7 +95,7 @@ func (sh *ShutdownHandler) Execute(ctx context.Context) error {
 	// Execute the shutdown function and process the result
 	err := sh.Handler(ctx)
 	if err != nil {
-		err = errors.E(op, errors.E(errors.Op(sh.Name), err))
+		err = errors.E(errors.E(err, errors.Op(sh.Name)), op)
 		switch sh.Policy {
 		case ErrorPolicyWarn:
 			log.Ctx(ctx).Warn().

--- a/avroutil/decoder.go
+++ b/avroutil/decoder.go
@@ -43,16 +43,16 @@ func (i *implDecoder) Decode(
 
 	schemaID, data, err := splitAvroWireFormatMessage(data)
 	if err != nil {
-		return errors.E(op, err, errors.SeverityInput)
+		return errors.E(err, op, errors.SeverityInput)
 	}
 
 	schema, err := i.schemaRepository.GetSchemaByID(ctx, schemaID)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	err = i.avroAPI.Unmarshal(schema, data, output)
-	return errors.E(op, err, errors.SeverityInput)
+	return errors.E(err, op, errors.SeverityInput)
 }
 
 // splitAvroWireFormatMessage extracts the schema ID and the data from a
@@ -62,10 +62,10 @@ func (i *implDecoder) Decode(
 func splitAvroWireFormatMessage(msg []byte) (schemaregistry.ID, []byte, error) {
 	const op = errors.Op("avroutil.SplitAvroWireFormatMessage")
 	if len(msg) < 5 {
-		return 0, nil, errors.E(op, "invalid message length")
+		return 0, nil, errors.New("invalid message length", op)
 	}
 	if msg[0] != 0x00 {
-		return 0, nil, errors.E(op, "invalid magic byte")
+		return 0, nil, errors.New("invalid magic byte", op)
 	}
 	schemaID := schemaregistry.ID(binary.BigEndian.Uint32(msg[1:5]))
 	data := msg[5:]

--- a/avroutil/encoder.go
+++ b/avroutil/encoder.go
@@ -39,12 +39,12 @@ func NewEncoder(
 
 	encoder, err := NewWireFormatEncoder(ctx, schemaRepository, subject, writerSchemaStr)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	parsedAvroSchema, err := avro.Parse(writerSchemaStr)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	return &implEncoder{
@@ -59,12 +59,12 @@ func (e *implEncoder) Encode(input interface{}) ([]byte, error) {
 
 	avroData, err := e.avroAPI.Marshal(e.writerSchema, input)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	wireFormat, err := e.wireFormatEncoder.BinaryToWireFormat(avroData)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	return wireFormat, nil

--- a/avroutil/wireformat_encoder.go
+++ b/avroutil/wireformat_encoder.go
@@ -40,7 +40,7 @@ func NewWireFormatEncoder(
 		writerSchemaStr,
 	)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 	return &wireFormatEncoder{
 		writerSchemaID: schemaID,
@@ -57,15 +57,15 @@ func (e *wireFormatEncoder) BinaryToWireFormat(avroInput []byte) ([]byte, error)
 	buf := new(bytes.Buffer)
 
 	if err := buf.WriteByte(0x00); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	if err := binary.Write(buf, binary.BigEndian, int32(e.writerSchemaID)); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	if _, err := buf.Write(avroInput); err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	return buf.Bytes(), nil

--- a/errors/code.go
+++ b/errors/code.go
@@ -10,14 +10,18 @@ import (
 type Code string
 
 // String returns the code as a string
-func (c Code) String() string {
-	return string(c)
+func (code Code) String() string {
+	return string(code)
 }
 
 // MarshalZerologObject allows for zerolog to
 // log the error code as 'error_code': '...'
-func (c Code) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("error_code", string(c))
+func (code Code) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("error_code", string(code))
+}
+
+func (code Code) Apply(err *Error) {
+	err.Code = code
 }
 
 const (

--- a/errors/code_test.go
+++ b/errors/code_test.go
@@ -33,9 +33,9 @@ func TestEqualsCode(t *testing.T) {
 }
 
 func TestSameCode(t *testing.T) {
-	errWithCodeTalker := E("Metal Gear Solid V: the Phantom Pain", Code("TALKER"))
-	anotherErrWithCodeTalker := E("Metal Gear Solid V: the Phantom Pain (goty)", Code("TALKER"))
-	errWithCodeVeronica := E("Resident Evil", Code("VERONICA"))
+	errWithCodeTalker := New("Metal Gear Solid V: the Phantom Pain", Code("TALKER"))
+	anotherErrWithCodeTalker := New("Metal Gear Solid V: the Phantom Pain (goty)", Code("TALKER"))
+	errWithCodeVeronica := New("Resident Evil", Code("VERONICA"))
 
 	assert.True(t, SameCode(errWithCodeTalker, anotherErrWithCodeTalker), "same code")
 	assert.False(t, SameCode(errWithCodeTalker, errWithCodeVeronica), "different codes")

--- a/errors/dontpanic.go
+++ b/errors/dontpanic.go
@@ -14,7 +14,7 @@ func DontPanic(f func()) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = NewFromRecover(r)
-			err = E(newOpFromPanicStack(), err)
+			err = E(err, newOpFromPanicStack())
 		}
 	}()
 

--- a/errors/dontpanic_test.go
+++ b/errors/dontpanic_test.go
@@ -108,14 +108,14 @@ func TestNewOpFromPanicStack_Recover(t *testing.T) {
 	op := newOpFromPanicStack()
 	assert.Equal(t, Op(""), op)
 
-	err := E(op, "new error without op")
+	err := New("new error without op", op)
 	assert.EqualError(t, err, "new error without op")
 }
 
 func TestNewFromRecover_UsingError(t *testing.T) {
-	err := NewFromRecover(E(
-		Op("TestNewFromRecover"),
+	err := NewFromRecover(New(
 		"new error",
+		Op("TestNewFromRecover"),
 		SeverityInput,
 		Code("CODE"),
 	))

--- a/errors/keyvalue.go
+++ b/errors/keyvalue.go
@@ -6,22 +6,32 @@ import (
 
 // KeyValue is used to store a key-value pair within the error
 type KeyValue struct {
-	Key   interface{}
-	Value interface{}
+	Key   any
+	Value any
 }
 
 func (kv KeyValue) String() string {
 	return fmt.Sprintf("%v=%v", kv.Key, kv.Value)
 }
 
+func (kv KeyValue) Apply(err *Error) {
+	err.KVs = append(err.KVs, kv)
+}
+
+type KeyValues []KeyValue
+
+func (kvs KeyValues) Apply(err *Error) {
+	err.KVs = append(err.KVs, kvs...)
+}
+
 // KV is a constructor for KeyValue types
-func KV(k, v interface{}) KeyValue {
+func KV(k, v any) KeyValue {
 	return KeyValue{Key: k, Value: v}
 }
 
 // GetRootErrorWithKV returns the Err field of Error struct or the error itself if it is of another type
 func GetRootErrorWithKV(err error) error {
-	var kvs []KeyValue
+	var kvs KeyValues
 
 	for {
 		if myErr, ok := err.(Error); ok && myErr.Err != nil {

--- a/errors/keyvalue_test.go
+++ b/errors/keyvalue_test.go
@@ -7,18 +7,18 @@ import (
 )
 
 func TestKVAppending(t *testing.T) {
-	err := E(SeverityFatal, "1st", KV("k1", "v1"), KV("k12", "v12"))
+	err := New("1st", SeverityFatal, KV("k1", "v1"), KV("k12", "v12"))
 	err = E(err, Op("2nd"))
-	err = E(Op("3rd"), []KeyValue{KV("k3", "v3")}, err)
+	err = E(err, Op("3rd"), KeyValues{KV("k3", "v3")})
 	err = E(err, Op("4th"))
 
 	assert.Equal(t, "4th: 3rd: 2nd: 1st [k3=v3,k1=v1,k12=v12]", err.Error())
 }
 
 func TestGetRootErrorWithKeyValue(t *testing.T) {
-	err := E("a")
-	err = E(Op("b"), err)
-	err = E(Op("c"), err)
-	err = E(Op("d"), KV("k", "v"), err)
+	err := New("a")
+	err = E(err, Op("b"))
+	err = E(err, Op("c"))
+	err = E(err, Op("d"), KV("k", "v"))
 	assert.EqualError(t, GetRootErrorWithKV(err), "a [k=v]")
 }

--- a/errors/op.go
+++ b/errors/op.go
@@ -3,6 +3,10 @@ package errors
 // Op is the operation that encapsulated the error
 type Op string
 
-func (o Op) String() string {
-	return string(o)
+func (op Op) String() string {
+	return string(op)
+}
+
+func (op Op) Apply(err *Error) {
+	err.Op = op
 }

--- a/errors/severity.go
+++ b/errors/severity.go
@@ -32,6 +32,10 @@ func (s Severity) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("error_severity", string(s))
 }
 
+func (s Severity) Apply(err *Error) {
+	err.Severity = s
+}
+
 // GetSeverity returns the error severity. If there is not severity, SeverityUnset is returned.
 func GetSeverity(err error) Severity {
 	for {

--- a/gzip/gzip.go
+++ b/gzip/gzip.go
@@ -14,11 +14,11 @@ func Compress(input []byte) ([]byte, error) {
 	zw := gzip.NewWriter(&buf)
 	_, err := zw.Write(input)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 	err = zw.Close()
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 	return buf.Bytes(), nil
 }
@@ -28,7 +28,7 @@ func MustCompress(input []byte) []byte {
 	const op = errors.Op("gzip.MustCompress")
 	output, err := Compress(input)
 	if err != nil {
-		panic(errors.E(op, err))
+		panic(errors.E(err, op))
 	}
 	return output
 }
@@ -39,13 +39,13 @@ func Decompress(input []byte) ([]byte, error) {
 	b := bytes.NewReader(input)
 	r, err := gzip.NewReader(b)
 	if err != nil {
-		return nil, errors.E(op, err, errors.KV("step", "gzip.NewReader"))
+		return nil, errors.E(err, op, errors.KV("step", "gzip.NewReader"))
 	}
 
 	var responseBuffer bytes.Buffer
 	_, err = responseBuffer.ReadFrom(r)
 	if err != nil {
-		return nil, errors.E(op, err, errors.KV("step", "responseBuffer.ReadFrom"))
+		return nil, errors.E(err, op, errors.KV("step", "responseBuffer.ReadFrom"))
 	}
 
 	return responseBuffer.Bytes(), nil
@@ -56,7 +56,7 @@ func MustDecompress(input []byte) []byte {
 	const op = errors.Op("gzip.MustDecompress")
 	output, err := Decompress(input)
 	if err != nil {
-		panic(errors.E(op, err))
+		panic(errors.E(err, op))
 	}
 	return output
 }

--- a/message/new.go
+++ b/message/new.go
@@ -36,12 +36,12 @@ func ParseTypeAndDataVersion(data interface{}) (Type, DataVersion, error) {
 	vIdx := strings.LastIndex(typeName, "V")
 
 	if vIdx < 1 || vIdx == len(typeName)-1 {
-		return "", 0, errors.E(op, errors.Errorf("invalid type name, expected '<type>V<version>' but got '%s'", typeName))
+		return "", 0, errors.E(errors.Errorf("invalid type name, expected '<type>V<version>' but got '%s'", typeName), op)
 	}
 
 	v, err := strconv.Atoi(typeName[vIdx+1:])
 	if err != nil {
-		return "", 0, errors.E(op, err)
+		return "", 0, errors.E(err, op)
 	}
 
 	runes := []rune(typeName[0:vIdx])
@@ -76,11 +76,11 @@ func New(ctx context.Context, source Source, data interface{}) (Message, error) 
 	const op = errors.Op("message.New")
 	messageType, messageDataVersion, err := ParseTypeAndDataVersion(data)
 	if err != nil {
-		return Message{}, errors.E(op, err)
+		return Message{}, errors.E(err, op)
 	}
 	d, err := json.Marshal(data)
 	if err != nil {
-		return Message{}, errors.E(op, err)
+		return Message{}, errors.E(err, op)
 	}
 	return Message{
 		SchemaVersion: SchemaVersion3,

--- a/retrier/generic_retry_evaluator.go
+++ b/retrier/generic_retry_evaluator.go
@@ -75,12 +75,12 @@ func (e *GenericRetryEvaluator) IsRetryable(attempt int, attemptError error) boo
 
 	canRetryOnErrorCode, err := isErrorCodeRetryable(errors.GetCode(attemptError), e.ErrorsCodesPolicy, e.ErrorsCodes)
 	if err != nil {
-		panic(errors.E(op, err))
+		panic(errors.E(err, op))
 	}
 
 	canRetryOnErrorSeverity, err := isErrorSeverityRetryable(errors.GetSeverity(attemptError), e.ErrorsSeveritiesPolicy, e.ErrorsSeverities)
 	if err != nil {
-		panic(errors.E(op, err))
+		panic(errors.E(err, op))
 	}
 
 	return canRetryOnErrorCode && canRetryOnErrorSeverity
@@ -112,7 +112,7 @@ func isErrorCodeRetryable(
 			return false, nil
 		}
 	default:
-		return false, errors.E(op, "bad evaluation policy")
+		return false, errors.New("bad evaluation policy", op)
 	}
 
 	return true, nil
@@ -144,7 +144,7 @@ func isErrorSeverityRetryable(
 			return false, nil
 		}
 	default:
-		return false, errors.E(op, "bad evaluation policy")
+		return false, errors.New("bad evaluation policy", op)
 	}
 
 	return true, nil

--- a/retrier/generic_retry_evaluator_test.go
+++ b/retrier/generic_retry_evaluator_test.go
@@ -33,7 +33,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				MaxAttempts: 5,
 			},
 			attemptNumber:       4,
-			attemptError:        errors.E("any error"),
+			attemptError:        errors.New("any error"),
 			expectedIsRetryable: true,
 		},
 		{
@@ -42,7 +42,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				MaxAttempts: 5,
 			},
 			attemptNumber:       5,
-			attemptError:        errors.E("any error"),
+			attemptError:        errors.New("any error"),
 			expectedIsRetryable: true,
 		},
 		{
@@ -51,7 +51,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				MaxAttempts: 5,
 			},
 			attemptNumber:       6,
-			attemptError:        errors.E("any error"),
+			attemptError:        errors.New("any error"),
 			expectedIsRetryable: false,
 		},
 		{
@@ -60,7 +60,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				ErrorsCodesPolicy: EvaluationPolicyBlacklist,
 				ErrorsCodes:       []errors.Code{someErrCode},
 			},
-			attemptError:        errors.E(someErrCode, "some error"),
+			attemptError:        errors.New("some error", someErrCode),
 			expectedIsRetryable: false,
 		},
 		{
@@ -69,7 +69,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				ErrorsCodesPolicy: EvaluationPolicyWhitelist,
 				ErrorsCodes:       []errors.Code{someErrCode},
 			},
-			attemptError:        errors.E(otherErrCode, "other error"),
+			attemptError:        errors.New("other error", otherErrCode),
 			expectedIsRetryable: false,
 		},
 		{
@@ -78,7 +78,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				ErrorsSeveritiesPolicy: EvaluationPolicyBlacklist,
 				ErrorsSeverities:       []errors.Severity{errors.SeverityFatal},
 			},
-			attemptError:        errors.E(errors.SeverityFatal, "fatal error"),
+			attemptError:        errors.New("fatal error", errors.SeverityFatal),
 			expectedIsRetryable: false,
 		},
 		{
@@ -87,7 +87,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				ErrorsSeveritiesPolicy: EvaluationPolicyWhitelist,
 				ErrorsSeverities:       []errors.Severity{errors.SeverityRuntime},
 			},
-			attemptError:        errors.E(errors.SeverityInput, "input error"),
+			attemptError:        errors.New("input error", errors.SeverityInput),
 			expectedIsRetryable: false,
 		},
 		{
@@ -98,7 +98,7 @@ func TestGenericRetryEvaluator_IsRetryable(t *testing.T) {
 				ErrorsSeveritiesPolicy: EvaluationPolicyBlacklist,
 				ErrorsSeverities:       []errors.Severity{errors.SeverityFatal},
 			},
-			attemptError:        errors.E(someErrCode, errors.SeverityRuntime, "informative error"),
+			attemptError:        errors.New("informative error", someErrCode, errors.SeverityRuntime),
 			expectedIsRetryable: true,
 		},
 	}

--- a/retrier/retrier_test.go
+++ b/retrier/retrier_test.go
@@ -48,7 +48,7 @@ func TestRetrier_ExecuteOperation_Success(t *testing.T) {
 	err := retrier.ExecuteOperation(func() error {
 		calls++
 		if calls <= 2 {
-			return errors.E(errors.SeverityRuntime, "some error")
+			return errors.New("some error", errors.SeverityRuntime)
 		}
 
 		return nil
@@ -75,7 +75,7 @@ func TestRetrier_ExecuteOperation_CorrectMaxRetriesAttempt(t *testing.T) {
 	calls := 0
 	err := retrier.ExecuteOperation(func() error {
 		calls++
-		return errors.E(errors.SeverityRuntime, "some error")
+		return errors.New("some error", errors.SeverityRuntime)
 	})
 
 	assert.Error(t, err, "Execute should return an error")

--- a/schemaregistry/implschemaregistry/cache.go
+++ b/schemaregistry/implschemaregistry/cache.go
@@ -36,7 +36,7 @@ func (r *cacheRepository) GetSchemaByID(ctx context.Context, id schemaregistry.I
 
 	schema, err := r.next.GetSchemaByID(ctx, id)
 	if err != nil {
-		return nil, errors.E(op, err)
+		return nil, errors.E(err, op)
 	}
 
 	r.storeSchemaByID(id, schema)
@@ -75,7 +75,7 @@ func (r *cacheRepository) GetIDBySchema(
 
 	id, avroSchema, err := r.next.GetIDBySchema(ctx, subject, schema)
 	if err != nil {
-		return id, nil, errors.E(op, err)
+		return id, nil, errors.E(err, op)
 	}
 
 	r.storeIDBySchema(id, schema)

--- a/schemaregistry/implschemaregistry/mock_repository.go
+++ b/schemaregistry/implschemaregistry/mock_repository.go
@@ -26,8 +26,8 @@ func MustNewMock(schemas map[schemaregistry.ID]string) schemaregistry.Repository
 		schema, err := avro.Parse(schemaStr)
 		if err != nil {
 			panic(errors.E(
-				op,
 				err,
+				op,
 				errors.KV("schema", truncateStr(schemaStr, 50)),
 			))
 		}
@@ -45,7 +45,7 @@ func (r mockRepository) GetSchemaByID(ctx context.Context, id schemaregistry.ID)
 		return schema, nil
 	}
 
-	return nil, errors.E(op, "could not find schema", errors.KV("id", id))
+	return nil, errors.New("could not find schema", errors.KV("id", id), op)
 }
 
 func (r mockRepository) GetIDBySchema(
@@ -57,14 +57,14 @@ func (r mockRepository) GetIDBySchema(
 
 	avroSchema, err := avro.Parse(schema)
 	if err != nil {
-		return 0, nil, errors.E(op, err)
+		return 0, nil, errors.E(err, op)
 	}
 
 	if id, ok := r.schemasToIDs[avroSchema.String()]; ok {
 		return id, avroSchema, nil
 	}
 
-	return 0, nil, errors.E(op, "could not find schema", errors.KV("subject", subject))
+	return 0, nil, errors.New("could not find schema", errors.KV("subject", subject), op)
 }
 
 func truncateStr(str string, size int) string {

--- a/sefaz/accesskey/validation.go
+++ b/sefaz/accesskey/validation.go
@@ -12,7 +12,7 @@ func Check(accessKey AccessKey) error {
 
 	err := validate(accessKey)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	return nil
@@ -25,13 +25,13 @@ func CheckNFF(accessKey AccessKey) error {
 
 	err := validate(accessKey)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	if isNFF(accessKey) {
 		err := validateNFF(accessKey)
 		if err != nil {
-			return errors.E(op, err)
+			return errors.E(err, op)
 		}
 	}
 
@@ -43,35 +43,35 @@ func validate(accessKey AccessKey) error {
 	const op errors.Op = "validate"
 
 	if accessKey == "" {
-		return errors.E(op, ErrEmptyAccessKey, ErrCodeEmptyAccessKey)
+		return errors.E(ErrEmptyAccessKey, ErrCodeEmptyAccessKey, op)
 	}
 
 	if len(accessKey) != 44 {
-		return errors.E(op, ErrInvalidLength, ErrCodeInvalidLength)
+		return errors.E(ErrInvalidLength, ErrCodeInvalidLength, op)
 	}
 
 	if !isDigitOnly(accessKey) {
-		return errors.E(op, ErrInvalidCharacter, ErrCodeInvalidCharacter)
+		return errors.E(ErrInvalidCharacter, ErrCodeInvalidCharacter, op)
 	}
 
 	if !isValidUF(accessKey[0:2].String()) {
-		return errors.E(op, ErrInvalidUF, ErrCodeInvalidUF)
+		return errors.E(ErrInvalidUF, ErrCodeInvalidUF, op)
 	}
 
 	if !isValidMonth(accessKey[4:6].String()) {
-		return errors.E(op, ErrInvalidMonth, ErrCodeInvalidMonth)
+		return errors.E(ErrInvalidMonth, ErrCodeInvalidMonth, op)
 	}
 
 	if !isValidCPFCNPJ(accessKey[6:20].String()) {
-		return errors.E(op, ErrInvalidCPFCNPJ, ErrCodeInvalidCPFCNPJ)
+		return errors.E(ErrInvalidCPFCNPJ, ErrCodeInvalidCPFCNPJ, op)
 	}
 
 	if !isValidModel(accessKey[20:22].String()) {
-		return errors.E(op, ErrInvalidModel, ErrCodeInvalidModel)
+		return errors.E(ErrInvalidModel, ErrCodeInvalidModel, op)
 	}
 
 	if !isValidationDigitCorrect(accessKey.String()) {
-		return errors.E(op, ErrInvalidDigit, ErrCodeInvalidDigit)
+		return errors.E(ErrInvalidDigit, ErrCodeInvalidDigit, op)
 	}
 
 	return nil
@@ -90,26 +90,26 @@ func validateNFF(accessKey AccessKey) error {
 	const op errors.Op = "validateNFF"
 
 	if !isValidSerieForNFF(accessKey[22:25].String()) {
-		return errors.E(op, ErrInvalidSerieForNFF, ErrCodeInvalidSerieForNFF)
+		return errors.E(ErrInvalidSerieForNFF, ErrCodeInvalidSerieForNFF, op)
 	}
 
 	if !isValidNumeroForNFF(accessKey[25:34].String()) {
-		return errors.E(op, ErrInvalidNumeroForNFF, ErrCodeInvalidNumeroForNFF)
+		return errors.E(ErrInvalidNumeroForNFF, ErrCodeInvalidNumeroForNFF, op)
 	}
 
 	if accessKey[29] == '1' {
 		err := stakeholder.CheckCNPJ(accessKey[6:20].String())
 		if err != nil {
-			return errors.E(op, err, ErrCodeInvalidCNPJForNFF)
+			return errors.E(err, op, ErrCodeInvalidCNPJForNFF)
 		}
 	} else if accessKey[29] == '2' {
 		if accessKey[6:9] != "000" {
-			return errors.E(op, "cpf is not padded with 0", ErrCodeInvalidCPFForNFF)
+			return errors.New("cpf is not padded with 0", ErrCodeInvalidCPFForNFF, op)
 		}
 
 		err := stakeholder.CheckCPF(accessKey[9:20].String())
 		if err != nil {
-			return errors.E(op, err, ErrCodeInvalidCPFForNFF)
+			return errors.E(err, op, ErrCodeInvalidCPFForNFF)
 		}
 	}
 

--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -21,7 +21,7 @@ func New(uf string) (CUF, error) {
 	ufInt, err := parseUF(uf)
 
 	if err != nil {
-		return CUF{}, errors.E(op, err)
+		return CUF{}, errors.E(err, op)
 	}
 	return CUF{true, ufInt}, nil
 }
@@ -47,7 +47,7 @@ func (c CUF) MarshalJSON() ([]byte, error) {
 	const op = errors.Op("CUF.MarshalJSON")
 
 	if !c.initialized {
-		return nil, errors.E(op, "CUF not initialized")
+		return nil, errors.New("CUF not initialized", op)
 	}
 	return json.Marshal(c.String())
 }
@@ -59,10 +59,10 @@ func (c *CUF) UnmarshalJSON(b []byte) error {
 
 	err := json.Unmarshal(b, &v)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 	if *c, err = New(v); err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	return nil

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -26,7 +26,7 @@ func (nsu NSU) MarshalJSON() ([]byte, error) {
 		const op = errors.Op("nsu.MarshalJSON")
 		b, err := json.Marshal(nsu.String())
 		if err != nil {
-			return nil, errors.E(op, err)
+			return nil, errors.E(err, op)
 		}
 		return b, nil
 	*/
@@ -38,11 +38,11 @@ func (nsu *NSU) UnmarshalJSON(b []byte) error {
 	var s string
 	err := json.Unmarshal(b, &s)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 	*nsu, err = Parse(s)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	return nil
@@ -64,15 +64,15 @@ func Parse(nsu string) (NSU, error) {
 	const op = errors.Op("nsu.Parse")
 
 	if len(nsu) == 0 {
-		return "", errors.E(op, "nsu is empty")
+		return "", errors.New("nsu is empty", op)
 	}
 	if len(nsu) > 15 {
-		return "", errors.E(op, "nsu has more than 15 digits")
+		return "", errors.New("nsu has more than 15 digits", op)
 	}
 
 	for i := 0; i < len(nsu); i++ {
 		if nsu[i]-'0' > 9 {
-			return "", errors.E(op, ErrCannotParse)
+			return "", errors.E(ErrCannotParse, op)
 		}
 	}
 

--- a/sefaz/stakeholder/stakeholder.go
+++ b/sefaz/stakeholder/stakeholder.go
@@ -25,11 +25,11 @@ func (s *Stakeholder) UnmarshalJSON(b []byte) error {
 	var v string
 	err := json.Unmarshal(b, &v)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 	*s, err = Parse(v)
 	if err != nil {
-		return errors.E(op, err)
+		return errors.E(err, op)
 	}
 
 	return nil
@@ -62,7 +62,7 @@ func Parse(s string) (Stakeholder, error) {
 	case TypePerson:
 		return NewCPF(s)
 	default:
-		return "", errors.E(op, newInvalidStakeholderTypeError(t))
+		return "", errors.E(newInvalidStakeholderTypeError(t), op)
 	}
 }
 

--- a/trace/v2/examples/services/ping/implping/adapter_pong_http.go
+++ b/trace/v2/examples/services/ping/implping/adapter_pong_http.go
@@ -47,7 +47,7 @@ func (a *adapterPongHTTP) Pong(
 		Sleep: sleep,
 	})
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err, op)
 	}
 
 	request, err := http.NewRequestWithContext(
@@ -57,14 +57,14 @@ func (a *adapterPongHTTP) Pong(
 		bytes.NewReader(body),
 	)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err, op)
 	}
 
 	trace.SetTraceInRequest(request)
 
 	httpResponse, err := a.client.Do(request)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err, op)
 	}
 	defer httpResponse.Body.Close()
 

--- a/trace/v2/examples/services/ping/services.go
+++ b/trace/v2/examples/services/ping/services.go
@@ -51,7 +51,7 @@ func (s *service) Ping(ctx context.Context, req Request) (string, error) {
 
 	pong, err := s.pongGateway.Pong(ctx, req.Num-1, req.Sleep)
 	if err != nil {
-		return "", errors.E(op, err)
+		return "", errors.E(err, op)
 	}
 
 	return pingpong + "-" + pong, nil


### PR DESCRIPTION
The errors.E() function receives a slice of any arguments. This makes this functions very easy to break or cause confusion because each argument must be type casted and processed.

Refactors errors.E() to receive the error as the first argument and a list of options. The Code, Op, Severity and KeyValue are now an ErrorOption.