### PR TITLE
Fix linter errors detected by newer versions of golangci-lint

### DIFF
--- a/app/shutdownhandler_test.go
+++ b/app/shutdownhandler_test.go
@@ -121,7 +121,7 @@ func TestShutdownHandlerExecute_Timeout(t *testing.T) {
 		Name: "my_failed_shutdown_handler",
 		Handler: func(ctx context.Context) error {
 			select {
-			case <-time.After(2 * time.Nanosecond):
+			case <-time.After(2 * time.Second):
 				return nil
 			case <-ctx.Done():
 				return errors.New("custom handler error on deadline exceeded")

--- a/avroutil/decoder.go
+++ b/avroutil/decoder.go
@@ -60,7 +60,7 @@ func (i *implDecoder) Decode(
 // The header is a 5-byte slice, where the first byte is equal to x00, and
 // the last four represent the ID in a 32-bit big endian integer encoding.
 func splitAvroWireFormatMessage(msg []byte) (schemaregistry.ID, []byte, error) {
-	const op = errors.Op("avroutil.SplitAvroWireFormatMessage")
+	const op = errors.Op("avroutil.splitAvroWireFormatMessage")
 	if len(msg) < 5 {
 		return 0, nil, errors.E(op, "invalid message length")
 	}

--- a/avroutil/wireformat_encoder.go
+++ b/avroutil/wireformat_encoder.go
@@ -60,7 +60,7 @@ func (e *wireFormatEncoder) BinaryToWireFormat(avroInput []byte) ([]byte, error)
 		return nil, errors.E(op, err)
 	}
 
-	if err := binary.Write(buf, binary.BigEndian, int32(e.writerSchemaID)); err != nil {
+	if err := binary.Write(buf, binary.BigEndian, uint32(e.writerSchemaID)); err != nil {
 		return nil, errors.E(op, err)
 	}
 

--- a/schemaregistry/repository.go
+++ b/schemaregistry/repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ID is the schema registry's schema ID
-type ID int
+type ID uint32
 
 // MarshalZerologObject implements the zerolog marshaler so it can be logged
 // using: log.With().EmbedObject(id).Msg("Some message")

--- a/sefaz/cuf/uf.go
+++ b/sefaz/cuf/uf.go
@@ -2,7 +2,6 @@ package cuf
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/arquivei/foundationkit/errors"
@@ -87,8 +86,10 @@ func parseUF(cUF string) (uint8, error) {
 	switch ufInt64 {
 	case 11, 12, 13, 14, 15, 16, 17, 21, 22, 23, 24, 25, 26, 27, 28, 29, 31, 32,
 		33, 35, 41, 42, 43, 50, 51, 52, 53:
+		// Disabling gosec as we put 8 as bitsize in uint
+		//nolint:gosec
 		return uint8(ufInt64), nil
 	default:
-		return 0, errors.Errorf(fmt.Sprintf("invalid cUF code: %s", cUF))
+		return uint8(0), errors.Errorf("invalid cUF code: %s", cUF)
 	}
 }

--- a/sefaz/nsu/nsu.go
+++ b/sefaz/nsu/nsu.go
@@ -86,7 +86,7 @@ func MustParse(s string) NSU {
 
 // ParseUint64 parses an integer into an NSU
 func ParseUint64(nsu uint64) (NSU, error) {
-	return Parse(strconv.FormatInt(int64(nsu), 10))
+	return Parse(strconv.FormatUint(nsu, 10))
 }
 
 // MustParseUint64 parses an integer into an NSU


### PR DESCRIPTION
New versions of golangci-lint are detecting more linter errors, which have been fixed by this changeset.

Most linter errors were due to casting between different types of int encodings. For avro wireformat ID, the ID has been set as uint32 (which is being used for decoding). I did a quick search if the avro id should be int or unit, and it seems unspecified. Since we're just matching ID's (to read or write), this should pose no risk.