### PR TITLE
Add validation for gosec lint validation

### DIFF
--- a/request/id.go
+++ b/request/id.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -64,7 +65,7 @@ func Parse(id string) (ID, error) {
 	}
 
 	return ID{
-		timestamp: uint64(timestamp),
+		timestamp: uint64(math.Abs(float64(timestamp))),
 		randomID:  slices[1],
 	}, nil
 }

--- a/request/id.go
+++ b/request/id.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -59,13 +58,13 @@ func Parse(id string) (ID, error) {
 		return ID{}, errors.New("wrong format for request id")
 	}
 
-	timestamp, err := strconv.Atoi(slices[0])
+	timestamp, err := strconv.ParseUint(slices[0], 10, 64)
 	if err != nil {
 		return ID{}, err
 	}
 
 	return ID{
-		timestamp: uint64(math.Abs(float64(timestamp))),
+		timestamp: timestamp,
 		randomID:  slices[1],
 	}, nil
 }

--- a/request/id_test.go
+++ b/request/id_test.go
@@ -61,7 +61,7 @@ func TestIDParse(t *testing.T) {
 		{
 			name:          "Without timestamp and with random ID",
 			input:         "-random",
-			expectedError: "strconv.Atoi: parsing \"\": invalid syntax",
+			expectedError: "strconv.ParseUint: parsing \"\": invalid syntax",
 		},
 		{
 			name:  "With timestamp and without random ID",
@@ -158,7 +158,7 @@ func TestIDUnmarshall(t *testing.T) {
 		{
 			name:          "Atoi failed",
 			json:          `{"ID":"a-01DVTM1P53ZVBRCCM4F9SCRK09"}`,
-			expectedError: `strconv.Atoi: parsing "a": invalid syntax`,
+			expectedError: `strconv.ParseUint: parsing "a": invalid syntax`,
 		},
 	}
 

--- a/request/id_test.go
+++ b/request/id_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIDString(t *testing.T) {
@@ -39,6 +40,53 @@ func TestIDString(t *testing.T) {
 	for _, test := range tests {
 		id := ID{test.timestamp, test.randomID}
 		assert.Equal(t, test.expected, id.String(), test.name)
+	}
+}
+
+func TestIDParse(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      ID
+		expectedError string
+	}{
+		{
+			name:  "With timestamp and random ID",
+			input: "19-random",
+			expected: ID{
+				timestamp: 19,
+				randomID:  "random",
+			},
+		},
+		{
+			name:          "Without timestamp and with random ID",
+			input:         "-random",
+			expectedError: "strconv.Atoi: parsing \"\": invalid syntax",
+		},
+		{
+			name:  "With timestamp and without random ID",
+			input: "19-",
+			expected: ID{
+				timestamp: 19,
+				randomID:  "",
+			},
+		},
+		{
+			name:          "Without timestamp and random ID",
+			input:         "",
+			expectedError: "wrong format for request id",
+		},
+	}
+
+	for _, test := range tests {
+		result, err := Parse(test.input)
+
+		if test.expectedError == "" {
+			require.NoError(t, err, test.name)
+			assert.Equal(t, test.expected, result, test.name)
+		} else {
+			assert.EqualError(t, err, test.expectedError, test.name)
+		}
 	}
 }
 


### PR DESCRIPTION
We were receiving the following error from CI/CD:
"integer overflow conversion int -> uint64 (gosec)"

To resolve this error, we must check if the number is negative.