### PR TITLE
fix: govulckeck

### DIFF
--- a/.github/workflows/govulcheck.yml
+++ b/.github/workflows/govulcheck.yml
@@ -17,6 +17,3 @@ jobs:
     steps:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: 1.21.5
-          go-package: ./...


### PR DESCRIPTION
Removes govulcheck go restriction. This was fixes to an older version of the go binary.